### PR TITLE
Add admin API endpoints and secure frontend workflows

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,9 @@
     "react-icons": "^5.3.0",
     "recharts": "^3.2.1",
     "sonner": "^2.0.7",
+    "swr": "^2.3.6",
     "tailwind-merge": "^2.4.0",
+    "zod": "^4.1.11",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -80,9 +80,15 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      swr:
+        specifier: ^2.3.6
+        version: 2.3.6(react@18.2.0)
       tailwind-merge:
         specifier: ^2.4.0
         version: 2.6.0
+      zod:
+        specifier: ^4.1.11
+        version: 4.1.11
       zustand:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@18.3.24)(immer@10.1.3)(react@18.2.0)(use-sync-external-store@1.5.0(react@18.2.0))
@@ -1253,6 +1259,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
@@ -2368,6 +2378,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.3.6:
+    resolution: {integrity: sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
@@ -2540,6 +2555,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zustand@5.0.8:
     resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
@@ -3674,6 +3692,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  dequal@2.0.3: {}
 
   detect-node-es@1.1.0: {}
 
@@ -4979,6 +4999,12 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.3.6(react@18.2.0):
+    dependencies:
+      dequal: 2.0.3
+      react: 18.2.0
+      use-sync-external-store: 1.5.0(react@18.2.0)
+
   tailwind-merge@2.6.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.17):
@@ -5234,6 +5260,8 @@ snapshots:
   yaml@2.8.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.1.11: {}
 
   zustand@5.0.8(@types/react@18.3.24)(immer@10.1.3)(react@18.2.0)(use-sync-external-store@1.5.0(react@18.2.0)):
     optionalDependencies:

--- a/web/src/app/api/_lib/auth.ts
+++ b/web/src/app/api/_lib/auth.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const AUTH_TOKEN = "demo-sanctum-token";
+
+export type AuthenticatedUser = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+export function buildUser(): AuthenticatedUser {
+  //1.- Provide a deterministic authenticated user for mocked Sanctum flows.
+  return {
+    id: 1,
+    name: "Demo User",
+    email: "demo.user@example.com",
+  };
+}
+
+export function extractToken(request: NextRequest): string | null {
+  //1.- Attempt to read the Bearer token from the Authorization header first.
+  const header = request.headers.get("authorization");
+  if (header?.startsWith("Bearer ")) {
+    const value = header.slice("Bearer ".length).trim();
+    if (value.length > 0) {
+      return value;
+    }
+  }
+
+  //2.- Fall back to the auth_token cookie that Playwright tests use for convenience.
+  const cookie = request.cookies.get("auth_token");
+  if (cookie?.value) {
+    return cookie.value;
+  }
+
+  //3.- When neither source provides a credential we treat the request as unauthenticated.
+  return null;
+}
+
+export function ensureSanctum(request: NextRequest): NextResponse | null {
+  //1.- Extract the provided credential from the incoming request.
+  const token = extractToken(request);
+  //2.- Compare the token against the demo Sanctum token and return a 401 when invalid.
+  if (token !== AUTH_TOKEN) {
+    return NextResponse.json({ message: "Unauthenticated." }, { status: 401 });
+  }
+  //3.- Returning null signals that the request is allowed to proceed.
+  return null;
+}

--- a/web/src/app/api/admin/_data/store.ts
+++ b/web/src/app/api/admin/_data/store.ts
@@ -1,0 +1,453 @@
+export type StoredPermission = {
+  id: number;
+  name: string;
+  display_name?: string;
+  description?: string;
+};
+
+export type StoredRole = {
+  id: number;
+  name: string;
+  display_name?: string;
+  description?: string;
+  permissionIds: number[];
+};
+
+export type TeamMember = {
+  userId: number;
+  role: string;
+};
+
+export type StoredTeam = {
+  id: number;
+  name: string;
+  description?: string;
+  members: TeamMember[];
+};
+
+export type StoredProfile = {
+  id: number;
+  userId: number;
+  name?: string;
+  phone?: string;
+  meta?: Record<string, unknown>;
+};
+
+export type StoredUser = {
+  id: number;
+  name: string;
+  email: string;
+  password: string;
+  roleIds: number[];
+  teamMemberships: { teamId: number; role: string }[];
+  profileId: number | null;
+};
+
+export type StoredSetting = {
+  id: number;
+  key: string;
+  value: string | null;
+  type: string | null;
+};
+
+type Store = {
+  permissions: StoredPermission[];
+  roles: StoredRole[];
+  teams: StoredTeam[];
+  profiles: StoredProfile[];
+  users: StoredUser[];
+  settings: StoredSetting[];
+  counters: {
+    permission: number;
+    role: number;
+    team: number;
+    profile: number;
+    user: number;
+    setting: number;
+  };
+};
+
+const store: Store = {
+  permissions: [
+    { id: 1, name: "users.read", display_name: "View users" },
+    { id: 2, name: "users.write", display_name: "Manage users" },
+    { id: 3, name: "teams.read", display_name: "View teams" },
+    { id: 4, name: "teams.write", display_name: "Manage teams" },
+  ],
+  roles: [
+    { id: 1, name: "admin", display_name: "Administrator", permissionIds: [1, 2, 3, 4] },
+    { id: 2, name: "manager", display_name: "Manager", permissionIds: [1, 3] },
+    { id: 3, name: "member", display_name: "Member", permissionIds: [3] },
+  ],
+  teams: [
+    {
+      id: 1,
+      name: "Engineering",
+      description: "Core product builders",
+      members: [],
+    },
+  ],
+  profiles: [],
+  users: [],
+  settings: [
+    { id: 1, key: "app.name", value: "Yamato", type: "string" },
+    { id: 2, key: "app.locale", value: "en", type: "string" },
+  ],
+  counters: {
+    permission: 5,
+    role: 4,
+    team: 2,
+    profile: 1,
+    user: 2,
+    setting: 3,
+  },
+};
+
+//1.- Seed the default demo user after related structures are defined.
+store.users.push({
+  id: 1,
+  name: "Demo User",
+  email: "demo.user@example.com",
+  password: "secret",
+  roleIds: [1],
+  teamMemberships: [{ teamId: 1, role: "owner" }],
+  profileId: null,
+});
+store.teams[0].members.push({ userId: 1, role: "owner" });
+
+function nextId(counter: keyof Store["counters"]): number {
+  //1.- Increment the requested counter and return the new identifier.
+  const value = store.counters[counter];
+  store.counters[counter] += 1;
+  return value;
+}
+
+export function listPermissions(): StoredPermission[] {
+  //1.- Return permissions ordered alphabetically by key name.
+  return [...store.permissions].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function listRoles(): StoredRole[] {
+  //1.- Expose all roles without mutating the in-memory store.
+  return [...store.roles];
+}
+
+export function listTeams(): StoredTeam[] {
+  //1.- Return teams with their member arrays intact for serialization.
+  return [...store.teams];
+}
+
+export function listProfiles(): StoredProfile[] {
+  //1.- Provide a shallow copy of profiles to prevent accidental mutation.
+  return [...store.profiles];
+}
+
+export function listUsers(): StoredUser[] {
+  //1.- Expose users from the store for serialization by the API routes.
+  return [...store.users];
+}
+
+export function listSettings(): StoredSetting[] {
+  //1.- Return settings ordered by key for deterministic responses.
+  return [...store.settings].sort((a, b) => a.key.localeCompare(b.key));
+}
+
+export function findPermission(id: number): StoredPermission | undefined {
+  //1.- Locate a permission by its identifier.
+  return store.permissions.find((permission) => permission.id === id);
+}
+
+export function findRole(id: number): StoredRole | undefined {
+  //1.- Locate a role within the store using its identifier.
+  return store.roles.find((role) => role.id === id);
+}
+
+export function findTeam(id: number): StoredTeam | undefined {
+  //1.- Locate a team using the in-memory list.
+  return store.teams.find((team) => team.id === id);
+}
+
+export function findProfile(id: number): StoredProfile | undefined {
+  //1.- Locate a profile by its identifier.
+  return store.profiles.find((profile) => profile.id === id);
+}
+
+export function findProfileByUserId(userId: number): StoredProfile | undefined {
+  //1.- Check for a profile that references the provided user id.
+  return store.profiles.find((profile) => profile.userId === userId);
+}
+
+export function findUser(id: number): StoredUser | undefined {
+  //1.- Locate a user record via the stored array.
+  return store.users.find((user) => user.id === id);
+}
+
+export function findSetting(id: number): StoredSetting | undefined {
+  //1.- Locate a setting record by its identifier.
+  return store.settings.find((setting) => setting.id === id);
+}
+
+export function emailExists(email: string, ignoreId?: number): boolean {
+  //1.- Confirm if an email address is already present in the user store.
+  return store.users.some((user) => user.email === email && user.id !== ignoreId);
+}
+
+export function roleNameExists(name: string, ignoreId?: number): boolean {
+  //1.- Confirm whether a role name already exists, excluding an optional id.
+  return store.roles.some((role) => role.name === name && role.id !== ignoreId);
+}
+
+export function permissionNameExists(name: string, ignoreId?: number): boolean {
+  //1.- Confirm whether a permission name already exists, excluding an optional id.
+  return store.permissions.some((permission) => permission.name === name && permission.id !== ignoreId);
+}
+
+export function teamNameExists(name: string, ignoreId?: number): boolean {
+  //1.- Check whether a team name is already used within the store.
+  return store.teams.some((team) => team.name === name && team.id !== ignoreId);
+}
+
+export function settingKeyExists(key: string, ignoreId?: number): boolean {
+  //1.- Check whether a setting key already exists in the store.
+  return store.settings.some((setting) => setting.key === key && setting.id !== ignoreId);
+}
+
+export function profileUserExists(userId: number, ignoreId?: number): boolean {
+  //1.- Determine whether a profile already references the provided user id.
+  return store.profiles.some((profile) => profile.userId === userId && profile.id !== ignoreId);
+}
+
+export function createPermission(payload: Omit<StoredPermission, "id">): StoredPermission {
+  //1.- Persist the permission with a new identifier in the in-memory store.
+  const permission: StoredPermission = { ...payload, id: nextId("permission") };
+  store.permissions.push(permission);
+  return permission;
+}
+
+export function updatePermission(id: number, payload: Partial<Omit<StoredPermission, "id">>): StoredPermission | undefined {
+  //1.- Locate the permission and merge incoming fields when present.
+  const permission = findPermission(id);
+  if (!permission) {
+    return undefined;
+  }
+  Object.assign(permission, payload);
+  return permission;
+}
+
+export function deletePermission(id: number): boolean {
+  //1.- Remove the permission and sync roles that reference it.
+  const index = store.permissions.findIndex((permission) => permission.id === id);
+  if (index === -1) {
+    return false;
+  }
+  store.permissions.splice(index, 1);
+  store.roles.forEach((role) => {
+    role.permissionIds = role.permissionIds.filter((permissionId) => permissionId !== id);
+  });
+  return true;
+}
+
+export function createRole(payload: Omit<StoredRole, "id">): StoredRole {
+  //1.- Attach a new id and store the role definition.
+  const role: StoredRole = { ...payload, id: nextId("role") };
+  store.roles.push(role);
+  return role;
+}
+
+export function updateRole(id: number, payload: Partial<Omit<StoredRole, "id">>): StoredRole | undefined {
+  //1.- Merge incoming fields into the existing role.
+  const role = findRole(id);
+  if (!role) {
+    return undefined;
+  }
+  Object.assign(role, payload);
+  return role;
+}
+
+export function deleteRole(id: number): boolean {
+  //1.- Remove the role and clean up user role assignments.
+  const index = store.roles.findIndex((role) => role.id === id);
+  if (index === -1) {
+    return false;
+  }
+  store.roles.splice(index, 1);
+  store.users.forEach((user) => {
+    user.roleIds = user.roleIds.filter((roleId) => roleId !== id);
+  });
+  return true;
+}
+
+export function createTeam(payload: Omit<StoredTeam, "id">): StoredTeam {
+  //1.- Assign an id and push the team into the store.
+  const team: StoredTeam = { ...payload, id: nextId("team") };
+  store.teams.push(team);
+  return team;
+}
+
+export function updateTeam(id: number, payload: Partial<Omit<StoredTeam, "id">>): StoredTeam | undefined {
+  //1.- Merge incoming changes into the stored team record.
+  const team = findTeam(id);
+  if (!team) {
+    return undefined;
+  }
+  Object.assign(team, payload);
+  return team;
+}
+
+export function deleteTeam(id: number): boolean {
+  //1.- Remove the team and detach memberships from users.
+  const index = store.teams.findIndex((team) => team.id === id);
+  if (index === -1) {
+    return false;
+  }
+  store.teams.splice(index, 1);
+  store.users.forEach((user) => {
+    user.teamMemberships = user.teamMemberships.filter((membership) => membership.teamId !== id);
+  });
+  return true;
+}
+
+export function createProfile(payload: Omit<StoredProfile, "id">): StoredProfile {
+  //1.- Persist the profile and return the stored record.
+  const profile: StoredProfile = { ...payload, id: nextId("profile") };
+  store.profiles.push(profile);
+  return profile;
+}
+
+export function updateProfile(id: number, payload: Partial<Omit<StoredProfile, "id">>): StoredProfile | undefined {
+  //1.- Locate and mutate the profile with the provided fields.
+  const profile = findProfile(id);
+  if (!profile) {
+    return undefined;
+  }
+  Object.assign(profile, payload);
+  return profile;
+}
+
+export function deleteProfile(id: number): boolean {
+  //1.- Remove the profile and unlink it from any associated user.
+  const index = store.profiles.findIndex((profile) => profile.id === id);
+  if (index === -1) {
+    return false;
+  }
+  const [profile] = store.profiles.splice(index, 1);
+  const user = findUser(profile.userId);
+  if (user) {
+    user.profileId = null;
+  }
+  return true;
+}
+
+export function createUser(payload: Omit<StoredUser, "id">): StoredUser {
+  //1.- Store the user with a generated identifier.
+  const user: StoredUser = { ...payload, id: nextId("user") };
+  store.users.push(user);
+  return user;
+}
+
+export function updateUser(id: number, payload: Partial<Omit<StoredUser, "id">>): StoredUser | undefined {
+  //1.- Merge incoming values into the stored user record.
+  const user = findUser(id);
+  if (!user) {
+    return undefined;
+  }
+  Object.assign(user, payload);
+  return user;
+}
+
+export function deleteUser(id: number): boolean {
+  //1.- Remove the user, clean memberships, and delete any attached profile.
+  const index = store.users.findIndex((user) => user.id === id);
+  if (index === -1) {
+    return false;
+  }
+  const [user] = store.users.splice(index, 1);
+  store.teams.forEach((team) => {
+    team.members = team.members.filter((member) => member.userId !== id);
+  });
+  if (user.profileId) {
+    deleteProfile(user.profileId);
+  }
+  return true;
+}
+
+export function createSetting(payload: Omit<StoredSetting, "id">): StoredSetting {
+  //1.- Persist the setting and expose the stored record.
+  const setting: StoredSetting = { ...payload, id: nextId("setting") };
+  store.settings.push(setting);
+  return setting;
+}
+
+export function updateSetting(id: number, payload: Partial<Omit<StoredSetting, "id">>): StoredSetting | undefined {
+  //1.- Merge new fields into the stored setting when present.
+  const setting = findSetting(id);
+  if (!setting) {
+    return undefined;
+  }
+  Object.assign(setting, payload);
+  return setting;
+}
+
+export function deleteSetting(id: number): boolean {
+  //1.- Remove the setting record from the in-memory array.
+  const index = store.settings.findIndex((setting) => setting.id === id);
+  if (index === -1) {
+    return false;
+  }
+  store.settings.splice(index, 1);
+  return true;
+}
+
+export function syncUserRoles(userId: number, roleIds: number[]): void {
+  //1.- Update the assigned role ids on the specified user.
+  const user = findUser(userId);
+  if (user) {
+    user.roleIds = [...roleIds];
+  }
+}
+
+export function syncUserTeams(userId: number, teams: { teamId: number; role: string }[]): void {
+  //1.- Replace the stored team memberships and update the team member lists.
+  const user = findUser(userId);
+  if (!user) {
+    return;
+  }
+  user.teamMemberships = [...teams];
+  store.teams.forEach((team) => {
+    team.members = team.members.filter((member) => member.userId !== userId);
+  });
+  teams.forEach((membership) => {
+    const team = findTeam(membership.teamId);
+    if (team) {
+      team.members.push({ userId, role: membership.role });
+    }
+  });
+}
+
+export function attachProfileToUser(userId: number, profileId: number | null): void {
+  //1.- Set the foreign key on the user for the profile relationship.
+  const user = findUser(userId);
+  if (user) {
+    user.profileId = profileId;
+  }
+}
+
+export function syncTeamMembers(teamId: number, members: TeamMember[]): void {
+  //1.- Replace the stored team members and update user memberships accordingly.
+  const team = findTeam(teamId);
+  if (!team) {
+    return;
+  }
+  team.members = [...members];
+
+  store.users.forEach((user) => {
+    user.teamMemberships = user.teamMemberships.filter((membership) => membership.teamId !== teamId);
+  });
+
+  members.forEach((member) => {
+    const user = findUser(member.userId);
+    if (user) {
+      user.teamMemberships.push({ teamId, role: member.role });
+    }
+  });
+}

--- a/web/src/app/api/admin/_lib/validation.ts
+++ b/web/src/app/api/admin/_lib/validation.ts
@@ -1,0 +1,325 @@
+import { z } from "zod";
+import {
+  StoredPermission,
+  StoredProfile,
+  StoredRole,
+  StoredSetting,
+  StoredTeam,
+  StoredUser,
+  attachProfileToUser,
+  findPermission,
+  findProfile,
+  findRole,
+  findSetting,
+  findTeam,
+  findUser,
+  listPermissions,
+  listProfiles,
+  listRoles,
+  listSettings,
+  listTeams,
+  syncUserRoles,
+  syncUserTeams,
+} from "@/app/api/admin/_data/store";
+
+const teamMembershipSchema = z.object({
+  id: z.number().int().positive(),
+  role: z.string().min(1),
+});
+
+const profilePayloadSchema = z.object({
+  name: z.string().min(1).optional(),
+  phone: z.string().min(1).optional(),
+  meta: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const userCreateSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+  roles: z.array(z.number().int().positive()).optional(),
+  teams: z.array(teamMembershipSchema).optional(),
+  profile: profilePayloadSchema.optional(),
+});
+
+export const userUpdateSchema = userCreateSchema
+  .omit({ password: true })
+  .extend({ password: z.string().min(6).optional() })
+  .partial({ name: true, email: true });
+
+export const roleCreateSchema = z.object({
+  name: z.string().min(1),
+  display_name: z.string().min(1).optional(),
+  description: z.string().min(1).optional(),
+  permissions: z.array(z.number().int().positive()).optional(),
+});
+
+export const roleUpdateSchema = roleCreateSchema.partial({
+  name: true,
+  display_name: true,
+  description: true,
+});
+
+export const permissionCreateSchema = z.object({
+  name: z.string().min(1),
+  display_name: z.string().min(1).optional(),
+  description: z.string().min(1).optional(),
+});
+
+export const permissionUpdateSchema = permissionCreateSchema.partial({
+  name: true,
+  display_name: true,
+  description: true,
+});
+
+export const profileCreateSchema = z.object({
+  user_id: z.number().int().positive(),
+  name: z.string().min(1).optional(),
+  phone: z.string().min(1).optional(),
+  meta: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const profileUpdateSchema = profileCreateSchema.partial({
+  user_id: true,
+  name: true,
+  phone: true,
+  meta: true,
+});
+
+export const teamCreateSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1).optional(),
+  members: z.array(teamMembershipSchema).optional(),
+});
+
+export const teamUpdateSchema = teamCreateSchema.partial({
+  name: true,
+  description: true,
+  members: true,
+});
+
+export const settingCreateSchema = z.object({
+  key: z.string().min(1),
+  value: z.string().nullable().optional(),
+  type: z.string().nullable().optional(),
+});
+
+export const settingUpdateSchema = settingCreateSchema.partial({
+  key: true,
+  value: true,
+  type: true,
+});
+
+type SerializedPermission = StoredPermission;
+
+type SerializedRole = StoredRole & {
+  permissions: SerializedPermission[];
+};
+
+type SerializedTeamMember = {
+  user: Pick<StoredUser, "id" | "name" | "email">;
+  role: string;
+};
+
+type SerializedTeam = {
+  id: number;
+  name: string;
+  description?: string;
+  members: SerializedTeamMember[];
+};
+
+type SerializedProfile = StoredProfile & { user: Pick<StoredUser, "id" | "name" | "email"> | null };
+
+type SerializedUser = {
+  id: number;
+  name: string;
+  email: string;
+  roles: SerializedRole[];
+  teams: Array<{ id: number; name: string; description?: string; role: string }>;
+  profile: SerializedProfile | null;
+};
+
+type SerializedSetting = StoredSetting;
+
+function serializePermission(permission: StoredPermission): SerializedPermission {
+  //1.- Return a shallow copy so responses remain immutable outside the store.
+  return { ...permission };
+}
+
+function serializeRole(role: StoredRole): SerializedRole {
+  //1.- Expand permission ids into full permission objects for consumers.
+  const permissions = role.permissionIds
+    .map((id) => findPermission(id))
+    .filter((permission): permission is StoredPermission => Boolean(permission))
+    .map(serializePermission);
+  return { ...role, permissions };
+}
+
+function serializeTeam(team: StoredTeam): SerializedTeam {
+  //1.- Embed minimal user data for each team member entry.
+  const members = team.members
+    .map((member) => {
+      const user = findUser(member.userId);
+      if (!user) {
+        return null;
+      }
+      return {
+        user: { id: user.id, name: user.name, email: user.email },
+        role: member.role,
+      };
+    })
+    .filter((member): member is SerializedTeamMember => Boolean(member));
+  return {
+    id: team.id,
+    name: team.name,
+    description: team.description,
+    members,
+  };
+}
+
+function serializeProfile(profile: StoredProfile | undefined): SerializedProfile | null {
+  //1.- Normalize optional profile relationships into a nullable structure with user context.
+  if (!profile) {
+    return null;
+  }
+  const user = findUser(profile.userId);
+  return { ...profile, user: user ? { id: user.id, name: user.name, email: user.email } : null };
+}
+
+export function serializeUser(user: StoredUser): SerializedUser {
+  //1.- Expand role identifiers into the hydrated role objects.
+  const roles = user.roleIds
+    .map((id) => findRole(id))
+    .filter((role): role is StoredRole => Boolean(role))
+    .map(serializeRole);
+
+  //2.- Expand team memberships with the related team details.
+  const teams = user.teamMemberships.reduce<Array<{ id: number; name: string; description?: string; role: string }>>(
+    (accumulator, membership) => {
+      const team = findTeam(membership.teamId);
+      if (team) {
+        accumulator.push({
+          id: team.id,
+          name: team.name,
+          description: team.description,
+          role: membership.role,
+        });
+      }
+      return accumulator;
+    },
+    [],
+  );
+
+  //3.- Attach the optional profile information for completeness.
+  const profile = serializeProfile(user.profileId ? findProfile(user.profileId) : undefined);
+
+  return {
+    id: user.id,
+    name: user.name,
+    email: user.email,
+    roles,
+    teams,
+    profile,
+  };
+}
+
+export function serializeRoleWithPermissions(role: StoredRole): SerializedRole {
+  //1.- Public wrapper for role serialization used by the API routes.
+  return serializeRole(role);
+}
+
+export function serializePermissionCollection(): SerializedPermission[] {
+  //1.- Provide an ordered permission list for the listing endpoint.
+  return listPermissions().map(serializePermission);
+}
+
+export function serializeRoleCollection(): SerializedRole[] {
+  //1.- Provide the full role collection with permission relationships.
+  return listRoles().map(serializeRole);
+}
+
+export function serializeTeamCollection(): SerializedTeam[] {
+  //1.- Provide teams with hydrated member references.
+  return listTeams().map(serializeTeam);
+}
+
+export function serializeTeamEntity(team: StoredTeam): SerializedTeam {
+  //1.- Expose a single team serialization helper for detail routes.
+  return serializeTeam(team);
+}
+
+export function serializeProfileCollection(): SerializedProfile[] {
+  //1.- Provide profiles with their owning user relationship hydrated.
+  return listProfiles()
+    .map((profile) => serializeProfile(profile)!)
+    .filter((profile): profile is SerializedProfile => Boolean(profile));
+}
+
+export function serializeProfileEntity(profile: StoredProfile): SerializedProfile {
+  //1.- Expose a single profile serialization helper for detail routes.
+  return serializeProfile(profile)!;
+}
+
+export function serializeSettings(): SerializedSetting[] {
+  //1.- Return ordered settings copies for predictable client consumption.
+  return listSettings().map((setting) => ({ ...setting }));
+}
+
+export function serializeSettingEntity(setting: StoredSetting): SerializedSetting {
+  //1.- Provide a helper for single setting serialization.
+  return { ...setting };
+}
+
+export function handleUserRelationships(user: StoredUser, roleIds: number[] | undefined, teams: { id: number; role: string }[] | undefined): void {
+  //1.- Sync roles when an explicit array is provided.
+  if (roleIds) {
+    syncUserRoles(user.id, roleIds);
+  }
+
+  //2.- Sync teams when membership payloads are present.
+  if (teams) {
+    syncUserTeams(
+      user.id,
+      teams.map((item) => ({ teamId: item.id, role: item.role })),
+    );
+  }
+}
+
+export function handleUserProfile(user: StoredUser, profilePayload: z.infer<typeof profilePayloadSchema> | undefined, create: (payload: Omit<StoredProfile, "id">) => StoredProfile, update: (id: number, payload: Partial<Omit<StoredProfile, "id">>) => StoredProfile | undefined): void {
+  //1.- Skip work when the request omits profile data entirely.
+  if (!profilePayload) {
+    return;
+  }
+
+  //2.- Create or update the profile depending on whether one already exists.
+  if (user.profileId) {
+    update(user.profileId, profilePayload);
+  } else {
+    const profile = create({ userId: user.id, ...profilePayload });
+    attachProfileToUser(user.id, profile.id);
+  }
+}
+
+export type ValidationResult<T> = { data: T } | { error: { [key: string]: string[] } };
+
+export function parseBody<T extends z.ZodTypeAny>(schema: T, body: unknown): ValidationResult<z.infer<T>> {
+  //1.- Attempt to parse the incoming payload with the provided schema.
+  const result = schema.safeParse(body);
+  if (!result.success) {
+    const errors: Record<string, string[]> = {};
+    result.error.issues.forEach((issue) => {
+      const path = issue.path.join(".") || "non_field_errors";
+      errors[path] = [...(errors[path] ?? []), issue.message];
+    });
+    return { error: errors };
+  }
+  return { data: result.data };
+}
+
+export function validationError(errors: Record<string, string[]>) {
+  //1.- Format validation errors to align with Laravel's default JSON structure.
+  return {
+    message: "The given data was invalid.",
+    errors,
+  };
+}

--- a/web/src/app/api/admin/permissions/[id]/route.ts
+++ b/web/src/app/api/admin/permissions/[id]/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import { deletePermission, findPermission, permissionNameExists, updatePermission } from "@/app/api/admin/_data/store";
+import { parseBody, validationError } from "@/app/api/admin/_lib/validation";
+import { permissionUpdateSchema } from "@/app/api/admin/_lib/validation";
+
+function parsePermissionId(params: { id: string }): number | null {
+  //1.- Convert the param into a valid identifier.
+  const value = Number(params.id);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function notFound() {
+  //1.- Provide a consistent 404 payload for missing permissions.
+  return NextResponse.json({ message: "Resource not found." }, { status: 404 });
+}
+
+function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Wrap validation errors inside Laravel's structure.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+async function guard(request: NextRequest) {
+  //1.- Apply the Sanctum guard and surface the response when invalid.
+  const response = ensureSanctum(request);
+  if (response) {
+    throw response;
+  }
+}
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parsePermissionId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const permission = findPermission(id);
+  if (!permission) {
+    return notFound();
+  }
+
+  return NextResponse.json({ data: permission }, { status: 200 });
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updatePermissionHandler(request, params);
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updatePermissionHandler(request, params);
+}
+
+async function updatePermissionHandler(request: NextRequest, params: { id: string }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parsePermissionId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const permission = findPermission(id);
+  if (!permission) {
+    return notFound();
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(permissionUpdateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { name, display_name, description } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (name !== undefined && permissionNameExists(name, permission.id)) {
+    errors.name = ["The permission name has already been taken."];
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const updates: Parameters<typeof updatePermission>[1] = {};
+  if (name !== undefined) {
+    updates.name = name;
+  }
+  if (display_name !== undefined) {
+    updates.display_name = display_name;
+  }
+  if (description !== undefined) {
+    updates.description = description;
+  }
+
+  const updated = updatePermission(permission.id, updates)!;
+  return NextResponse.json({ data: updated }, { status: 200 });
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parsePermissionId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const permission = findPermission(id);
+  if (!permission) {
+    return notFound();
+  }
+
+  deletePermission(id);
+  return new NextResponse(null, { status: 204 });
+}

--- a/web/src/app/api/admin/permissions/route.ts
+++ b/web/src/app/api/admin/permissions/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import { createPermission, permissionNameExists } from "@/app/api/admin/_data/store";
+import {
+  parseBody,
+  serializePermissionCollection,
+  validationError,
+} from "@/app/api/admin/_lib/validation";
+import { permissionCreateSchema } from "@/app/api/admin/_lib/validation";
+
+function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Return validation errors using the standard JSON envelope.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Check Sanctum credentials before returning the permission catalogue.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  return NextResponse.json({ data: serializePermissionCollection() }, { status: 200 });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  //1.- Protect creation with Sanctum.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(permissionCreateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { name, display_name, description } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (permissionNameExists(name)) {
+    errors.name = ["The permission name has already been taken."];
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const permission = createPermission({ name, display_name, description });
+  return NextResponse.json({ data: permission }, { status: 201 });
+}

--- a/web/src/app/api/admin/profiles/[id]/route.ts
+++ b/web/src/app/api/admin/profiles/[id]/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import {
+  attachProfileToUser,
+  deleteProfile,
+  findProfile,
+  findUser,
+  profileUserExists,
+  updateProfile,
+} from "@/app/api/admin/_data/store";
+import {
+  parseBody,
+  serializeProfileEntity,
+  validationError,
+} from "@/app/api/admin/_lib/validation";
+import { profileUpdateSchema } from "@/app/api/admin/_lib/validation";
+
+function parseProfileId(params: { id: string }): number | null {
+  //1.- Convert the param into an integer identifier when possible.
+  const value = Number(params.id);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function notFound() {
+  //1.- Provide a JSON 404 response compatible with Laravel conventions.
+  return NextResponse.json({ message: "Resource not found." }, { status: 404 });
+}
+
+function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Shape validation errors to mirror Laravel's JSON format.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+async function guard(request: NextRequest) {
+  //1.- Invoke the Sanctum guard helper for consistency.
+  const response = ensureSanctum(request);
+  if (response) {
+    throw response;
+  }
+}
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseProfileId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const profile = findProfile(id);
+  if (!profile) {
+    return notFound();
+  }
+
+  return NextResponse.json({ data: serializeProfileEntity(profile) }, { status: 200 });
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateProfileHandler(request, params);
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateProfileHandler(request, params);
+}
+
+async function updateProfileHandler(request: NextRequest, params: { id: string }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseProfileId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const profile = findProfile(id);
+  if (!profile) {
+    return notFound();
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(profileUpdateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { user_id, name, phone, meta } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (user_id !== undefined) {
+    const targetUser = findUser(user_id);
+    if (!targetUser) {
+      errors.user_id = ["The selected user does not exist."];
+    } else if (profileUserExists(user_id, profile.id)) {
+      errors.user_id = ["The user already has a profile."];
+    }
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const updates: Parameters<typeof updateProfile>[1] = {};
+  if (user_id !== undefined) {
+    attachProfileToUser(profile.userId, null);
+    updates.userId = user_id;
+  }
+  if (name !== undefined) {
+    updates.name = name;
+  }
+  if (phone !== undefined) {
+    updates.phone = phone;
+  }
+  if (meta !== undefined) {
+    updates.meta = meta;
+  }
+
+  const updated = updateProfile(profile.id, updates)!;
+  if (user_id !== undefined) {
+    attachProfileToUser(user_id, updated.id);
+  }
+
+  return NextResponse.json({ data: serializeProfileEntity(updated) }, { status: 200 });
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseProfileId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const profile = findProfile(id);
+  if (!profile) {
+    return notFound();
+  }
+
+  deleteProfile(id);
+  return new NextResponse(null, { status: 204 });
+}

--- a/web/src/app/api/admin/profiles/route.ts
+++ b/web/src/app/api/admin/profiles/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import { attachProfileToUser, createProfile, findUser, profileUserExists } from "@/app/api/admin/_data/store";
+import {
+  parseBody,
+  serializeProfileCollection,
+  serializeProfileEntity,
+  validationError,
+} from "@/app/api/admin/_lib/validation";
+import { profileCreateSchema } from "@/app/api/admin/_lib/validation";
+
+function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Return validation errors using the Laravel-compatible envelope.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Ensure the listing is only available to authenticated callers.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  return NextResponse.json({ data: serializeProfileCollection() }, { status: 200 });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  //1.- Enforce Sanctum authentication.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(profileCreateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { user_id, name, phone, meta } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  const user = findUser(user_id);
+  if (!user) {
+    errors.user_id = ["The selected user does not exist."];
+  } else if (profileUserExists(user_id)) {
+    errors.user_id = ["The user already has a profile."];
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const profile = createProfile({ userId: user_id, name, phone, meta });
+  attachProfileToUser(user_id, profile.id);
+
+  return NextResponse.json({ data: serializeProfileEntity(profile) }, { status: 201 });
+}

--- a/web/src/app/api/admin/roles/[id]/route.ts
+++ b/web/src/app/api/admin/roles/[id]/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import { deleteRole, findRole, roleNameExists, updateRole } from "@/app/api/admin/_data/store";
+import {
+  parseBody,
+  serializeRoleWithPermissions,
+} from "@/app/api/admin/_lib/validation";
+import { roleUpdateSchema } from "@/app/api/admin/_lib/validation";
+import { buildValidationResponse, validatePermissions } from "@/app/api/admin/roles/helpers";
+
+function parseRoleId(params: { id: string }): number | null {
+  //1.- Convert the path segment into a usable numeric identifier.
+  const value = Number(params.id);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function notFound() {
+  //1.- Provide a consistent 404 response payload.
+  return NextResponse.json({ message: "Resource not found." }, { status: 404 });
+}
+
+async function guard(request: NextRequest) {
+  //1.- Reuse the Sanctum helper to short-circuit unauthenticated requests.
+  const response = ensureSanctum(request);
+  if (response) {
+    throw response;
+  }
+}
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseRoleId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const role = findRole(id);
+  if (!role) {
+    return notFound();
+  }
+
+  return NextResponse.json({ data: serializeRoleWithPermissions(role) }, { status: 200 });
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateRoleHandler(request, params);
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateRoleHandler(request, params);
+}
+
+async function updateRoleHandler(request: NextRequest, params: { id: string }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseRoleId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const role = findRole(id);
+  if (!role) {
+    return notFound();
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(roleUpdateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { name, display_name, description, permissions } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (name !== undefined && roleNameExists(name, role.id)) {
+    errors.name = ["The role name has already been taken."];
+  }
+  Object.assign(errors, validatePermissions(permissions));
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const updates: Parameters<typeof updateRole>[1] = {};
+  if (name !== undefined) {
+    updates.name = name;
+  }
+  if (display_name !== undefined) {
+    updates.display_name = display_name;
+  }
+  if (description !== undefined) {
+    updates.description = description;
+  }
+  if (permissions !== undefined) {
+    updates.permissionIds = permissions;
+  }
+
+  updateRole(role.id, updates);
+
+  return NextResponse.json({ data: serializeRoleWithPermissions(findRole(role.id)!) }, { status: 200 });
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseRoleId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const role = findRole(id);
+  if (!role) {
+    return notFound();
+  }
+
+  deleteRole(id);
+  return new NextResponse(null, { status: 204 });
+}

--- a/web/src/app/api/admin/roles/helpers.ts
+++ b/web/src/app/api/admin/roles/helpers.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { findPermission } from "@/app/api/admin/_data/store";
+import { validationError } from "@/app/api/admin/_lib/validation";
+
+export function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Format validation errors consistently with Laravel responses.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+export function validatePermissions(permissions: number[] | undefined) {
+  //1.- Ensure all supplied permission identifiers exist.
+  if (!permissions) {
+    return {};
+  }
+  const missing = permissions.filter((id) => !findPermission(id));
+  return missing.length > 0 ? { permissions: ["One or more permissions do not exist."] } : {};
+}

--- a/web/src/app/api/admin/roles/route.ts
+++ b/web/src/app/api/admin/roles/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import { createRole, roleNameExists } from "@/app/api/admin/_data/store";
+import {
+  parseBody,
+  serializeRoleCollection,
+  serializeRoleWithPermissions,
+} from "@/app/api/admin/_lib/validation";
+import { roleCreateSchema } from "@/app/api/admin/_lib/validation";
+import { buildValidationResponse, validatePermissions } from "@/app/api/admin/roles/helpers";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Guard the request with the Sanctum helper before exposing data.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  //2.- Return roles with their permissions eager-loaded.
+  return NextResponse.json({ data: serializeRoleCollection() }, { status: 200 });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  //1.- Protect the mutation endpoint with Sanctum.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(roleCreateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { name, display_name, description, permissions } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (roleNameExists(name)) {
+    errors.name = ["The role name has already been taken."];
+  }
+  Object.assign(errors, validatePermissions(permissions));
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const role = createRole({
+    name,
+    display_name,
+    description,
+    permissionIds: permissions ?? [],
+  });
+
+  return NextResponse.json({ data: serializeRoleWithPermissions(role) }, { status: 201 });
+}

--- a/web/src/app/api/admin/settings/[id]/route.ts
+++ b/web/src/app/api/admin/settings/[id]/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import { deleteSetting, findSetting, settingKeyExists, updateSetting } from "@/app/api/admin/_data/store";
+import {
+  parseBody,
+  serializeSettingEntity,
+  validationError,
+} from "@/app/api/admin/_lib/validation";
+import { settingUpdateSchema } from "@/app/api/admin/_lib/validation";
+
+function parseSettingId(params: { id: string }): number | null {
+  //1.- Convert the path segment into a valid numeric identifier.
+  const value = Number(params.id);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function notFound() {
+  //1.- Return a JSON 404 payload consistent with Laravel.
+  return NextResponse.json({ message: "Resource not found." }, { status: 404 });
+}
+
+function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Present validation errors using Laravel's JSON structure.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+async function guard(request: NextRequest) {
+  //1.- Enforce Sanctum authentication for all handlers.
+  const response = ensureSanctum(request);
+  if (response) {
+    throw response;
+  }
+}
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseSettingId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const setting = findSetting(id);
+  if (!setting) {
+    return notFound();
+  }
+
+  return NextResponse.json({ data: serializeSettingEntity(setting) }, { status: 200 });
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateSettingHandler(request, params);
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateSettingHandler(request, params);
+}
+
+async function updateSettingHandler(request: NextRequest, params: { id: string }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseSettingId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const setting = findSetting(id);
+  if (!setting) {
+    return notFound();
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(settingUpdateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { key, value = null, type = null } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (key !== undefined && settingKeyExists(key, setting.id)) {
+    errors.key = ["The key has already been taken."];
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const updates: Parameters<typeof updateSetting>[1] = {};
+  if (key !== undefined) {
+    updates.key = key;
+  }
+  if (value !== undefined) {
+    updates.value = value;
+  }
+  if (type !== undefined) {
+    updates.type = type;
+  }
+
+  const updated = updateSetting(setting.id, updates)!;
+  return NextResponse.json({ data: serializeSettingEntity(updated) }, { status: 200 });
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseSettingId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const setting = findSetting(id);
+  if (!setting) {
+    return notFound();
+  }
+
+  deleteSetting(id);
+  return new NextResponse(null, { status: 204 });
+}

--- a/web/src/app/api/admin/settings/route.ts
+++ b/web/src/app/api/admin/settings/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import { createSetting, settingKeyExists } from "@/app/api/admin/_data/store";
+import {
+  parseBody,
+  serializeSettings,
+  serializeSettingEntity,
+  validationError,
+} from "@/app/api/admin/_lib/validation";
+import { settingCreateSchema } from "@/app/api/admin/_lib/validation";
+
+function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Present validation errors in the Laravel-compatible format.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Authenticate the caller before returning configuration data.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  return NextResponse.json({ data: serializeSettings() }, { status: 200 });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  //1.- Protect the endpoint with Sanctum.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(settingCreateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { key, value = null, type = null } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (settingKeyExists(key)) {
+    errors.key = ["The key has already been taken."];
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const setting = createSetting({ key, value: value ?? null, type: type ?? null });
+  return NextResponse.json({ data: serializeSettingEntity(setting) }, { status: 201 });
+}

--- a/web/src/app/api/admin/teams/[id]/route.ts
+++ b/web/src/app/api/admin/teams/[id]/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import {
+  deleteTeam,
+  findTeam,
+  findUser,
+  syncTeamMembers,
+  teamNameExists,
+  updateTeam,
+} from "@/app/api/admin/_data/store";
+import {
+  parseBody,
+  serializeTeamEntity,
+  validationError,
+} from "@/app/api/admin/_lib/validation";
+import { teamUpdateSchema } from "@/app/api/admin/_lib/validation";
+
+function parseTeamId(params: { id: string }): number | null {
+  //1.- Parse the dynamic segment into an integer identifier.
+  const value = Number(params.id);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function notFound() {
+  //1.- Return a Laravel-style JSON 404 response.
+  return NextResponse.json({ message: "Resource not found." }, { status: 404 });
+}
+
+function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Format validation errors for API consumers.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+async function guard(request: NextRequest) {
+  //1.- Ensure Sanctum credentials are present.
+  const response = ensureSanctum(request);
+  if (response) {
+    throw response;
+  }
+}
+
+function sanitizeMembers(members: { id: number; role: string }[] | undefined) {
+  //1.- Convert the public members payload into TeamMember entries.
+  if (!members) {
+    return [] as { userId: number; role: string }[];
+  }
+  return members.map((member) => ({ userId: member.id, role: member.role }));
+}
+
+function validateMembers(members: { id: number; role: string }[] | undefined) {
+  //1.- Validate that member user ids exist.
+  const errors: Record<string, string[]> = {};
+  if (!members) {
+    return errors;
+  }
+  const missing = members.filter((member) => !findUser(member.id));
+  if (missing.length > 0) {
+    errors.members = ["One or more users could not be found."];
+  }
+  return errors;
+}
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseTeamId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const team = findTeam(id);
+  if (!team) {
+    return notFound();
+  }
+
+  return NextResponse.json({ data: serializeTeamEntity(team) }, { status: 200 });
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateTeamHandler(request, params);
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateTeamHandler(request, params);
+}
+
+async function updateTeamHandler(request: NextRequest, params: { id: string }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseTeamId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const team = findTeam(id);
+  if (!team) {
+    return notFound();
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(teamUpdateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { name, description, members } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (name !== undefined && teamNameExists(name, team.id)) {
+    errors.name = ["The team name has already been taken."];
+  }
+  Object.assign(errors, validateMembers(members));
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const updates: Parameters<typeof updateTeam>[1] = {};
+  if (name !== undefined) {
+    updates.name = name;
+  }
+  if (description !== undefined) {
+    updates.description = description;
+  }
+  if (Object.keys(updates).length > 0) {
+    updateTeam(team.id, updates);
+  }
+
+  if (members !== undefined) {
+    const sanitizedMembers = sanitizeMembers(members);
+    syncTeamMembers(team.id, sanitizedMembers);
+  }
+
+  return NextResponse.json({ data: serializeTeamEntity(findTeam(team.id)!) }, { status: 200 });
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await guard(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseTeamId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const team = findTeam(id);
+  if (!team) {
+    return notFound();
+  }
+
+  deleteTeam(id);
+  return new NextResponse(null, { status: 204 });
+}

--- a/web/src/app/api/admin/teams/route.ts
+++ b/web/src/app/api/admin/teams/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import {
+  createTeam,
+  findUser,
+  syncTeamMembers,
+  teamNameExists,
+} from "@/app/api/admin/_data/store";
+import {
+  parseBody,
+  serializeTeamCollection,
+  serializeTeamEntity,
+  validationError,
+} from "@/app/api/admin/_lib/validation";
+import { teamCreateSchema } from "@/app/api/admin/_lib/validation";
+
+function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Output validation feedback mirroring Laravel's response contract.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+function sanitizeMembers(members: { id: number; role: string }[] | undefined) {
+  //1.- Convert incoming member payloads into the internal TeamMember structure.
+  if (!members) {
+    return [] as { userId: number; role: string }[];
+  }
+  return members.map((member) => ({ userId: member.id, role: member.role }));
+}
+
+function validateMembers(members: { id: number; role: string }[] | undefined) {
+  //1.- Ensure referenced users exist before attaching them to a team.
+  const errors: Record<string, string[]> = {};
+  if (!members) {
+    return errors;
+  }
+  const missing = members.filter((member) => !findUser(member.id));
+  if (missing.length > 0) {
+    errors.members = ["One or more users could not be found."];
+  }
+  return errors;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Require Sanctum authentication before exposing the team catalogue.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  return NextResponse.json({ data: serializeTeamCollection() }, { status: 200 });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  //1.- Guard the creation endpoint using the shared helper.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(teamCreateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { name, description, members } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (teamNameExists(name)) {
+    errors.name = ["The team name has already been taken."];
+  }
+  Object.assign(errors, validateMembers(members));
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const team = createTeam({ name, description, members: [] });
+  const sanitizedMembers = sanitizeMembers(members);
+  syncTeamMembers(team.id, sanitizedMembers);
+
+  return NextResponse.json({ data: serializeTeamEntity(team) }, { status: 201 });
+}

--- a/web/src/app/api/admin/users/[id]/route.ts
+++ b/web/src/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,144 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import {
+  createProfile,
+  deleteUser,
+  emailExists,
+  findUser,
+  updateProfile,
+  updateUser,
+} from "@/app/api/admin/_data/store";
+import {
+  handleUserProfile,
+  handleUserRelationships,
+  parseBody,
+  serializeUser,
+  userUpdateSchema,
+} from "@/app/api/admin/_lib/validation";
+import { buildValidationResponse, validateAssociations } from "@/app/api/admin/users/helpers";
+
+function parseUserId(params: { id: string }): number | null {
+  //1.- Convert the dynamic segment into a positive integer identifier.
+  const value = Number(params.id);
+  return Number.isInteger(value) && value > 0 ? value : null;
+}
+
+function notFound() {
+  //1.- Mirror Laravel's default JSON payload for missing resources.
+  return NextResponse.json({ message: "Resource not found." }, { status: 404 });
+}
+
+async function ensureAuthenticated(request: NextRequest) {
+  //1.- Reuse the Sanctum helper to reject unauthenticated requests early.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    throw guard;
+  }
+}
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await ensureAuthenticated(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  //1.- Validate the identifier before looking up the user.
+  const id = parseUserId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const user = findUser(id);
+  if (!user) {
+    return notFound();
+  }
+
+  //2.- Return the hydrated user resource.
+  return NextResponse.json({ data: serializeUser(user) }, { status: 200 });
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateUserHandler(request, params);
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  return updateUserHandler(request, params);
+}
+
+async function updateUserHandler(request: NextRequest, params: { id: string }): Promise<NextResponse> {
+  try {
+    await ensureAuthenticated(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseUserId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const user = findUser(id);
+  if (!user) {
+    return notFound();
+  }
+
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(userUpdateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { name, email, password, roles, teams, profile } = parsed.data;
+
+  const errors: Record<string, string[]> = {};
+  if (email !== undefined && emailExists(email, user.id)) {
+    errors.email = ["The email has already been taken."];
+  }
+
+  Object.assign(errors, validateAssociations(roles, teams));
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  const updates: Partial<Parameters<typeof updateUser>[1]> = {};
+  if (name !== undefined) {
+    updates.name = name;
+  }
+  if (email !== undefined) {
+    updates.email = email;
+  }
+  if (password !== undefined) {
+    updates.password = password;
+  }
+  if (Object.keys(updates).length > 0) {
+    updateUser(user.id, updates);
+  }
+
+  handleUserRelationships(user, roles, teams);
+  handleUserProfile(user, profile, createProfile, updateProfile);
+
+  return NextResponse.json({ data: serializeUser(user) }, { status: 200 });
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }): Promise<NextResponse> {
+  try {
+    await ensureAuthenticated(request);
+  } catch (response) {
+    return response as NextResponse;
+  }
+
+  const id = parseUserId(params);
+  if (!id) {
+    return notFound();
+  }
+
+  const user = findUser(id);
+  if (!user) {
+    return notFound();
+  }
+
+  deleteUser(id);
+  return new NextResponse(null, { status: 204 });
+}

--- a/web/src/app/api/admin/users/helpers.ts
+++ b/web/src/app/api/admin/users/helpers.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { findRole, findTeam } from "@/app/api/admin/_data/store";
+import { validationError } from "@/app/api/admin/_lib/validation";
+
+export function buildValidationResponse(errors: Record<string, string[]>) {
+  //1.- Wrap validation errors in a Sanctum-style JSON response.
+  return NextResponse.json(validationError(errors), { status: 422 });
+}
+
+export function validateAssociations(roles: number[] | undefined, teams: { id: number; role: string }[] | undefined) {
+  //1.- Collect association errors for invalid role or team identifiers.
+  const errors: Record<string, string[]> = {};
+
+  if (roles) {
+    const missing = roles.filter((id) => !findRole(id));
+    if (missing.length > 0) {
+      errors.roles = ["One or more roles do not exist."];
+    }
+  }
+
+  if (teams) {
+    const missingTeam = teams.filter((item) => !findTeam(item.id));
+    if (missingTeam.length > 0) {
+      errors["teams"] = ["One or more teams do not exist."];
+    }
+  }
+
+  return errors;
+}

--- a/web/src/app/api/admin/users/route.ts
+++ b/web/src/app/api/admin/users/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ensureSanctum } from "@/app/api/_lib/auth";
+import { createProfile, createUser, emailExists, listUsers, updateProfile } from "@/app/api/admin/_data/store";
+import {
+  handleUserProfile,
+  handleUserRelationships,
+  parseBody,
+  serializeUser,
+  userCreateSchema,
+} from "@/app/api/admin/_lib/validation";
+import { buildValidationResponse, validateAssociations } from "@/app/api/admin/users/helpers";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Ensure the caller is authenticated under the Sanctum guard.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  //2.- Serialize all users with eager-loaded relationships for the admin list.
+  const users = listUsers().map(serializeUser);
+  return NextResponse.json({ data: users }, { status: 200 });
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  //1.- Enforce Sanctum authentication before mutating user data.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  //2.- Parse the incoming JSON body using the shared schema.
+  const json = await request.json().catch(() => ({}));
+  const parsed = parseBody(userCreateSchema, json);
+  if ("error" in parsed) {
+    return buildValidationResponse(parsed.error);
+  }
+
+  const { name, email, password, roles, teams, profile } = parsed.data;
+
+  //3.- Perform additional integrity checks that rely on the in-memory store state.
+  const errors: Record<string, string[]> = {};
+  if (emailExists(email)) {
+    errors.email = ["The email has already been taken."];
+  }
+
+  Object.assign(errors, validateAssociations(roles, teams));
+
+  if (Object.keys(errors).length > 0) {
+    return buildValidationResponse(errors);
+  }
+
+  //4.- Create the base user record before applying relationships.
+  const user = createUser({
+    name,
+    email,
+    password,
+    roleIds: roles ?? [],
+    teamMemberships: [],
+    profileId: null,
+  });
+
+  //5.- Sync roles, teams, and profile payloads as requested.
+  handleUserRelationships(user, roles ?? [], teams ?? []);
+  handleUserProfile(user, profile, createProfile, updateProfile);
+
+  //6.- Return the serialized user with relations eagerly loaded.
+  return NextResponse.json({ data: serializeUser(user) }, { status: 201 });
+}

--- a/web/src/app/api/secure/dashboard/route.ts
+++ b/web/src/app/api/secure/dashboard/route.ts
@@ -1,49 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-
-const AUTH_TOKEN = "demo-sanctum-token";
-
-type AuthenticatedUser = {
-  id: number;
-  name: string;
-  email: string;
-};
+import { buildUser, ensureSanctum } from "@/app/api/_lib/auth";
 
 type SecureDashboardResponse = {
-  user: AuthenticatedUser;
+  user: ReturnType<typeof buildUser>;
   meta: {
     section: string;
     message: string;
   };
 };
-
-function extractToken(request: NextRequest): string | null {
-  //1.- Check the Authorization header for a Bearer token first.
-  const authorizationHeader = request.headers.get("authorization");
-  if (authorizationHeader?.startsWith("Bearer ")) {
-    const headerToken = authorizationHeader.slice("Bearer ".length).trim();
-    if (headerToken.length > 0) {
-      return headerToken;
-    }
-  }
-
-  //2.- If the header is missing, fall back to the auth_token cookie used during tests.
-  const authCookie = request.cookies.get("auth_token");
-  if (authCookie?.value) {
-    return authCookie.value;
-  }
-
-  //3.- When neither credential exists we treat the request as unauthenticated.
-  return null;
-}
-
-function buildUser(): AuthenticatedUser {
-  //1.- Provide a deterministic mock user for local development and tests.
-  return {
-    id: 1,
-    name: "Demo User",
-    email: "demo.user@example.com",
-  };
-}
 
 function buildResponseBody(): SecureDashboardResponse {
   //1.- Compose the response structure expected by the secure dashboard client.
@@ -57,10 +21,10 @@ function buildResponseBody(): SecureDashboardResponse {
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  //1.- Guard the route by extracting and validating the provided token.
-  const token = extractToken(request);
-  if (token !== AUTH_TOKEN) {
-    return NextResponse.json({ message: "Unauthenticated." }, { status: 401 });
+  //1.- Guard the route using the shared Sanctum helper and bail out on failure.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
   }
 
   //2.- When the token is valid, return the authenticated user with secure meta data.

--- a/web/src/app/api/secure/errors/route.ts
+++ b/web/src/app/api/secure/errors/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildUser, ensureSanctum } from "@/app/api/_lib/auth";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Require authentication before revealing the errors section metadata.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  //2.- Deliver the user payload with the errors section identifier.
+  return NextResponse.json(
+    {
+      user: buildUser(),
+      meta: {
+        section: "errors",
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/web/src/app/api/secure/logs/route.ts
+++ b/web/src/app/api/secure/logs/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildUser, ensureSanctum } from "@/app/api/_lib/auth";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Protect the logs section using the shared Sanctum guard.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  //2.- Send back the authenticated user with the logs section descriptor.
+  return NextResponse.json(
+    {
+      user: buildUser(),
+      meta: {
+        section: "logs",
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/web/src/app/api/secure/profile/route.ts
+++ b/web/src/app/api/secure/profile/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildUser, ensureSanctum } from "@/app/api/_lib/auth";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Ensure the caller is authenticated before returning the profile payload.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  //2.- Provide the current user and tag the response with the profile section meta.
+  return NextResponse.json(
+    {
+      user: buildUser(),
+      meta: {
+        section: "profile",
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/web/src/app/api/secure/users/route.ts
+++ b/web/src/app/api/secure/users/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildUser, ensureSanctum } from "@/app/api/_lib/auth";
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  //1.- Validate Sanctum credentials before exposing the secure users payload.
+  const guard = ensureSanctum(request);
+  if (guard) {
+    return guard;
+  }
+
+  //2.- Return the authenticated user alongside the users meta section marker.
+  return NextResponse.json(
+    {
+      user: buildUser(),
+      meta: {
+        section: "users",
+      },
+    },
+    { status: 200 },
+  );
+}

--- a/web/src/app/private/users/page.tsx
+++ b/web/src/app/private/users/page.tsx
@@ -1,11 +1,20 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import Shell from "@/components/secure/shell"
+import AdminUsersPanel from "@/components/secure/users/AdminUsersPanel"
 
 export default function Page() {
   return (
     <Shell>
       <div className="grid gap-6">
-        <Card><CardHeader><CardTitle>Users</CardTitle></CardHeader><CardContent><p className="text-sm text-muted-foreground">List, invite, suspend. Permissions-aware.</p></CardContent></Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Users</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="mb-4 text-sm text-muted-foreground">List, invite, suspend. Permissions-aware.</p>
+            <AdminUsersPanel />
+          </CardContent>
+        </Card>
       </div>
     </Shell>
   )

--- a/web/src/components/secure/users/AdminUsersPanel.tsx
+++ b/web/src/components/secure/users/AdminUsersPanel.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAdminResource } from "@/hooks/use-admin-resource";
+import { adminUserSchema } from "@/lib/validation/admin";
+import { getStoredToken, setStoredToken } from "@/lib/api-client";
+
+type Role = {
+  id: number;
+  name: string;
+  display_name?: string;
+};
+
+type Team = {
+  id: number;
+  name: string;
+  role: string;
+};
+
+type Profile = {
+  id: number;
+  phone?: string;
+  name?: string;
+  meta?: Record<string, unknown>;
+};
+
+type AdminUser = {
+  id: number;
+  name: string;
+  email: string;
+  roles: Role[];
+  teams: Team[];
+  profile: Profile | null;
+};
+
+export default function AdminUsersPanel() {
+  //1.- Ensure the demo Sanctum token exists so the API requests succeed locally.
+  useEffect(() => {
+    if (!getStoredToken()) {
+      setStoredToken("demo-sanctum-token");
+    }
+  }, []);
+
+  const { items, isLoading, error, create } = useAdminResource<AdminUser>("/api/admin/users");
+
+  async function handleSeedUser() {
+    //1.- Build a unique payload, validate it with Zod, and trigger the mutation with optimism.
+    const timestamp = Date.now();
+    const payload = adminUserSchema.parse({
+      name: `Seeded User ${timestamp}`,
+      email: `seeded.user.${timestamp}@example.com`,
+      password: "secret123",
+      roles: [],
+      teams: [],
+      profile: { name: `Seeded User ${timestamp}` },
+    });
+    await create(payload, {
+      optimistic: {
+        id: timestamp,
+        name: payload.name,
+        email: payload.email,
+        roles: [],
+        teams: [],
+        profile: { id: timestamp, name: payload.profile?.name },
+      },
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Users</h2>
+        {/* //1.- Provide a quick action that seeds a demo user with optimistic updates. */}
+        <button
+          type="button"
+          className="rounded bg-primary px-3 py-2 text-sm font-medium text-primary-foreground"
+          onClick={handleSeedUser}
+        >
+          Seed user
+        </button>
+      </div>
+      {isLoading && <p className="text-sm text-muted-foreground">Loading users…</p>}
+      {error && <p className="text-sm text-red-500">Failed to load users: {(error as Error).message}</p>}
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="py-2">Name</th>
+            <th>Email</th>
+            <th>Roles</th>
+            <th>Teams</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((user) => (
+            <tr key={user.id} className="border-b last:border-0">
+              <td className="py-2 font-medium">{user.name}</td>
+              <td>{user.email}</td>
+              <td>{user.roles.map((role) => role.display_name ?? role.name).join(", ") || "—"}</td>
+              <td>{user.teams.map((team) => `${team.name} (${team.role})`).join(", ") || "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/hooks/use-admin-resource.ts
+++ b/web/src/hooks/use-admin-resource.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import useSWR, { useSWRConfig } from "swr";
+import { apiMutation, apiRequest } from "@/lib/api-client";
+
+type AdminListResponse<T> = { data: T[] };
+type AdminSingleResponse<T> = { data: T };
+
+type Identifiable = { id: number };
+
+type CreateOptions<T> = {
+  optimistic?: T;
+};
+
+type UpdateOptions<T> = {
+  optimistic?: T;
+};
+
+type DeleteOptions = {
+  optimisticId?: number;
+};
+
+export function useAdminResource<T extends Identifiable>(path: string) {
+  //1.- Fetch the admin list using SWR so the UI stays in sync with mutations.
+  const { data, error, isLoading, mutate } = useSWR<AdminListResponse<T>>(path, (url: string) =>
+    apiRequest<AdminListResponse<T>>(url),
+  );
+  const { mutate: globalMutate } = useSWRConfig();
+
+  async function create(payload: unknown, options: CreateOptions<T> = {}) {
+    //1.- Perform the POST request with optimistic data appended to the cache.
+    await mutate(
+      async (current) => {
+        const response = await apiMutation<AdminSingleResponse<T>>(path, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        return { data: [...(current?.data ?? []), response.data] };
+      },
+      {
+        optimisticData: {
+          data: [...(data?.data ?? []), ...(options.optimistic ? [options.optimistic] : [])],
+        },
+        rollbackOnError: true,
+        revalidate: false,
+      },
+    );
+  }
+
+  async function update(id: number, payload: unknown, options: UpdateOptions<T> = {}) {
+    //1.- Send a PATCH request and optimistically merge the response into the cache.
+    const url = `${path}/${id}`;
+    await mutate(
+      async (current) => {
+        const response = await apiMutation<AdminSingleResponse<T>>(url, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        return {
+          data: (current?.data ?? []).map((item) => (item.id === id ? response.data : item)),
+        };
+      },
+      {
+        optimisticData: {
+          data: (data?.data ?? []).map((item) => (item.id === id && options.optimistic ? options.optimistic : item)),
+        },
+        rollbackOnError: true,
+        revalidate: false,
+      },
+    );
+  }
+
+  async function destroy(id: number, options: DeleteOptions = {}) {
+    //1.- Issue the DELETE request and optimistically filter the item from cache.
+    const url = `${path}/${id}`;
+    await mutate(
+      async (current) => {
+        await apiMutation<unknown>(url, { method: "DELETE" });
+        return { data: (current?.data ?? []).filter((item) => item.id !== id) };
+      },
+      {
+        optimisticData: {
+          data: (data?.data ?? []).filter((item) => item.id !== (options.optimisticId ?? id)),
+        },
+        rollbackOnError: true,
+        revalidate: false,
+      },
+    );
+  }
+
+  async function refresh() {
+    //1.- Revalidate the cache through SWR's global mutate utility.
+    await globalMutate(path);
+  }
+
+  return {
+    items: data?.data ?? [],
+    isLoading,
+    error,
+    create,
+    update,
+    destroy,
+    refresh,
+  } as const;
+}

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -1,0 +1,60 @@
+"use client";
+
+const AUTH_TOKEN_STORAGE_KEY = "yamato.authToken";
+
+export function getStoredToken(): string | null {
+  //1.- Safely read the stored auth token when running in the browser.
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+}
+
+export function clearStoredToken() {
+  //1.- Remove the persisted token so future requests are forced to re-authenticate.
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+}
+
+export function setStoredToken(token: string) {
+  //1.- Persist the provided token for subsequent authenticated requests.
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+}
+
+export async function apiRequest<T>(input: RequestInfo, init: RequestInit = {}): Promise<T> {
+  //1.- Build the headers, including the stored Bearer token when available.
+  const headers = new Headers(init.headers);
+  const token = getStoredToken();
+  if (token && !headers.has("authorization")) {
+    headers.set("authorization", `Bearer ${token}`);
+  }
+
+  //2.- Execute the network request using the provided arguments.
+  const response = await fetch(input, { ...init, headers });
+
+  //3.- Handle authentication errors by clearing credentials and redirecting.
+  if (response.status === 401 || response.status === 419) {
+    clearStoredToken();
+    if (typeof window !== "undefined") {
+      window.location.href = "/login";
+    }
+    throw new Error("Authentication required");
+  }
+
+  //4.- Parse the JSON payload for convenience in data hooks.
+  const data = await response.json();
+  if (!response.ok) {
+    throw new Error(data?.message ?? "Request failed");
+  }
+  return data as T;
+}
+
+export async function apiMutation<T>(input: RequestInfo, init: RequestInit = {}): Promise<T> {
+  //1.- Reuse apiRequest to maintain consistent error handling for mutations.
+  return apiRequest<T>(input, init);
+}

--- a/web/src/lib/validation/admin.ts
+++ b/web/src/lib/validation/admin.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+//1.- Mirror the backend validation rules so client-side forms stay consistent.
+export const adminTeamMemberSchema = z.object({
+  id: z.number().int().positive(),
+  role: z.string().min(1),
+});
+
+export const adminProfileSchema = z.object({
+  user_id: z.number().int().positive(),
+  name: z.string().min(1).optional(),
+  phone: z.string().min(1).optional(),
+  meta: z.record(z.string(), z.unknown()).optional(),
+});
+
+export const adminUserSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+  roles: z.array(z.number().int().positive()).optional(),
+  teams: z.array(adminTeamMemberSchema).optional(),
+  profile: adminProfileSchema.omit({ user_id: true }).optional(),
+});
+
+export const adminRoleSchema = z.object({
+  name: z.string().min(1),
+  display_name: z.string().min(1).optional(),
+  description: z.string().min(1).optional(),
+  permissions: z.array(z.number().int().positive()).optional(),
+});
+
+export const adminPermissionSchema = z.object({
+  name: z.string().min(1),
+  display_name: z.string().min(1).optional(),
+  description: z.string().min(1).optional(),
+});
+
+export const adminTeamSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().min(1).optional(),
+  members: z.array(adminTeamMemberSchema).optional(),
+});
+
+export const adminSettingSchema = z.object({
+  key: z.string().min(1),
+  value: z.string().nullable().optional(),
+  type: z.string().nullable().optional(),
+});

--- a/web/tests/admin-permissions.spec.ts
+++ b/web/tests/admin-permissions.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_HEADER = "Bearer demo-sanctum-token";
+
+let createdPermissionId: number;
+
+test.describe("Admin permissions API", () => {
+  test("lists permissions", async ({ request }) => {
+    //1.- Retrieve the ordered permission list to ensure availability.
+    const response = await request.get("/api/admin/permissions", {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data[0]).toHaveProperty("name");
+  });
+
+  test("creates a permission", async ({ request }) => {
+    //1.- Register a new permission for integration testing purposes.
+    const response = await request.post("/api/admin/permissions", {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        name: "integration.permission",
+        display_name: "Integration Permission",
+      },
+    });
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.data.name).toBe("integration.permission");
+    createdPermissionId = body.data.id;
+  });
+
+  test("shows the created permission", async ({ request }) => {
+    //1.- Fetch the permission by id to confirm persistence.
+    const response = await request.get(`/api/admin/permissions/${createdPermissionId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.id).toBe(createdPermissionId);
+    expect(body.data.name).toBe("integration.permission");
+  });
+
+  test("updates the permission", async ({ request }) => {
+    //1.- Adjust the permission metadata.
+    const response = await request.patch(`/api/admin/permissions/${createdPermissionId}`, {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        display_name: "Updated Integration Permission",
+      },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.display_name).toBe("Updated Integration Permission");
+  });
+
+  test("deletes the permission", async ({ request }) => {
+    //1.- Remove the test permission to keep the in-memory store tidy.
+    const response = await request.delete(`/api/admin/permissions/${createdPermissionId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(204);
+  });
+});

--- a/web/tests/admin-profiles.spec.ts
+++ b/web/tests/admin-profiles.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_HEADER = "Bearer demo-sanctum-token";
+
+let profileId: number;
+let profileUserId: number;
+
+test.describe("Admin profiles API", () => {
+  test("lists profiles with users", async ({ request }) => {
+    //1.- Fetch the profiles index to ensure it returns an array payload.
+    const response = await request.get("/api/admin/profiles", {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.data)).toBe(true);
+  });
+
+  test("creates a profile for a user", async ({ request }) => {
+    //1.- Create a user that the profile will belong to.
+    const timestamp = Date.now();
+    const userResponse = await request.post("/api/admin/users", {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        name: `Profile Subject ${timestamp}`,
+        email: `profile.subject.${timestamp}@example.com`,
+        password: "secret123",
+      },
+    });
+    expect(userResponse.status()).toBe(201);
+    profileUserId = (await userResponse.json()).data.id;
+
+    //2.- Attach the profile payload to the newly created user.
+    const response = await request.post("/api/admin/profiles", {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        user_id: profileUserId,
+        name: "Profile Subject",
+        phone: "+15559999999",
+      },
+    });
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.data.user?.id).toBe(profileUserId);
+    expect(body.data.phone).toBe("+15559999999");
+    profileId = body.data.id;
+  });
+
+  test("shows the created profile", async ({ request }) => {
+    //1.- Retrieve the profile to ensure the user relationship is present.
+    const response = await request.get(`/api/admin/profiles/${profileId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.id).toBe(profileId);
+    expect(body.data.user.id).toBe(profileUserId);
+  });
+
+  test("updates the profile details", async ({ request }) => {
+    //1.- Update the profile with new metadata.
+    const response = await request.patch(`/api/admin/profiles/${profileId}`, {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        phone: "+15558888888",
+        meta: { timezone: "UTC" },
+      },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.phone).toBe("+15558888888");
+    expect(body.data.meta).toEqual({ timezone: "UTC" });
+  });
+
+  test("deletes the profile and cleanup user", async ({ request }) => {
+    //1.- Remove the profile record and confirm the response code.
+    const response = await request.delete(`/api/admin/profiles/${profileId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(204);
+
+    //2.- Delete the associated user to keep the store tidy.
+    const userResponse = await request.delete(`/api/admin/users/${profileUserId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(userResponse.status()).toBe(204);
+  });
+});

--- a/web/tests/admin-roles.spec.ts
+++ b/web/tests/admin-roles.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_HEADER = "Bearer demo-sanctum-token";
+
+let createdRoleId: number;
+
+test.describe("Admin roles API", () => {
+  test("lists roles with permissions", async ({ request }) => {
+    //1.- Request the roles collection to ensure permissions are eager-loaded.
+    const response = await request.get("/api/admin/roles", {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(Array.isArray(body.data[0].permissions)).toBe(true);
+  });
+
+  test("creates a role with permission assignments", async ({ request }) => {
+    //1.- Submit a new role with associated permission identifiers.
+    const response = await request.post("/api/admin/roles", {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        name: "integration-role",
+        display_name: "Integration Role",
+        description: "Role created during integration tests",
+        permissions: [1, 2],
+      },
+    });
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.data.name).toBe("integration-role");
+    expect(body.data.permissions).toHaveLength(2);
+    createdRoleId = body.data.id;
+  });
+
+  test("shows the created role", async ({ request }) => {
+    //1.- Retrieve the role detail to confirm it includes permissions.
+    const response = await request.get(`/api/admin/roles/${createdRoleId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.id).toBe(createdRoleId);
+    expect(body.data.permissions).toHaveLength(2);
+  });
+
+  test("updates the role and syncs permissions", async ({ request }) => {
+    //1.- Adjust the role metadata and provide a new permission set.
+    const response = await request.patch(`/api/admin/roles/${createdRoleId}`, {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        display_name: "Updated Integration Role",
+        permissions: [3],
+      },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.display_name).toBe("Updated Integration Role");
+    expect(body.data.permissions.map((perm: any) => perm.id)).toEqual([3]);
+  });
+
+  test("deletes the role", async ({ request }) => {
+    //1.- Remove the created role to leave the store clean for other tests.
+    const response = await request.delete(`/api/admin/roles/${createdRoleId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(204);
+  });
+});

--- a/web/tests/admin-settings.spec.ts
+++ b/web/tests/admin-settings.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_HEADER = "Bearer demo-sanctum-token";
+
+let settingId: number;
+
+test.describe("Admin settings API", () => {
+  test("lists settings", async ({ request }) => {
+    //1.- Fetch the settings collection to confirm ordering.
+    const response = await request.get("/api/admin/settings", {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data[0]).toHaveProperty("key");
+  });
+
+  test("creates a setting", async ({ request }) => {
+    //1.- Register a new configuration key.
+    const response = await request.post("/api/admin/settings", {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        key: "integration.mode",
+        value: "enabled",
+        type: "string",
+      },
+    });
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.data.key).toBe("integration.mode");
+    settingId = body.data.id;
+  });
+
+  test("shows the created setting", async ({ request }) => {
+    //1.- Fetch the setting by id to confirm persistence.
+    const response = await request.get(`/api/admin/settings/${settingId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.id).toBe(settingId);
+    expect(body.data.key).toBe("integration.mode");
+  });
+
+  test("updates the setting", async ({ request }) => {
+    //1.- Adjust the stored value to confirm updates succeed.
+    const response = await request.patch(`/api/admin/settings/${settingId}`, {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        value: "disabled",
+      },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.value).toBe("disabled");
+  });
+
+  test("deletes the setting", async ({ request }) => {
+    //1.- Remove the setting to keep the store clean.
+    const response = await request.delete(`/api/admin/settings/${settingId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(204);
+  });
+});

--- a/web/tests/admin-teams.spec.ts
+++ b/web/tests/admin-teams.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_HEADER = "Bearer demo-sanctum-token";
+
+let teamId: number;
+let teamUserId: number;
+
+test.describe("Admin teams API", () => {
+  test("lists teams with members", async ({ request }) => {
+    //1.- Fetch the teams index to ensure member relationships are present.
+    const response = await request.get("/api/admin/teams", {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(Array.isArray(body.data[0].members)).toBe(true);
+  });
+
+  test("creates a team with members", async ({ request }) => {
+    //1.- Create a supporting user that will join the team.
+    const userResponse = await request.post("/api/admin/users", {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        name: "Team Member",
+        email: "team.member@example.com",
+        password: "secret123",
+      },
+    });
+    expect(userResponse.status()).toBe(201);
+    teamUserId = (await userResponse.json()).data.id;
+
+    //2.- Create the team with the new member included.
+    const response = await request.post("/api/admin/teams", {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        name: "Quality Assurance",
+        description: "QA squad",
+        members: [{ id: teamUserId, role: "lead" }],
+      },
+    });
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.data.name).toBe("Quality Assurance");
+    expect(body.data.members[0].user.id).toBe(teamUserId);
+    expect(body.data.members[0].role).toBe("lead");
+    teamId = body.data.id;
+  });
+
+  test("shows the created team", async ({ request }) => {
+    //1.- Retrieve the team and confirm the member hydration.
+    const response = await request.get(`/api/admin/teams/${teamId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.id).toBe(teamId);
+    expect(body.data.members[0].user.id).toBe(teamUserId);
+  });
+
+  test("updates the team and member roles", async ({ request }) => {
+    //1.- Update the team description and member role assignment.
+    const response = await request.patch(`/api/admin/teams/${teamId}`, {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        description: "Updated QA squad",
+        members: [{ id: teamUserId, role: "mentor" }],
+      },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.description).toBe("Updated QA squad");
+    expect(body.data.members[0].role).toBe("mentor");
+  });
+
+  test("deletes the team and cleanup member", async ({ request }) => {
+    //1.- Remove the team to restore the initial state.
+    const response = await request.delete(`/api/admin/teams/${teamId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(204);
+
+    //2.- Delete the temporary user created for the team.
+    const userResponse = await request.delete(`/api/admin/users/${teamUserId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(userResponse.status()).toBe(204);
+  });
+});

--- a/web/tests/admin-users.spec.ts
+++ b/web/tests/admin-users.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_HEADER = "Bearer demo-sanctum-token";
+
+let createdUserId: number;
+
+test.describe("Admin users API", () => {
+  test("lists users with eager-loaded relationships", async ({ request }) => {
+    //1.- Fetch the users index to confirm the relationships are expanded.
+    const response = await request.get("/api/admin/users", {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(Array.isArray(body.data)).toBe(true);
+    const demoUser = body.data.find((user: any) => user.email === "demo.user@example.com");
+    expect(demoUser).toBeDefined();
+    expect(Array.isArray(demoUser.roles)).toBe(true);
+    expect(Array.isArray(demoUser.teams)).toBe(true);
+  });
+
+  test("creates a user with roles, teams, and profile", async ({ request }) => {
+    //1.- Submit the creation payload with roles, teams, and profile data.
+    const response = await request.post("/api/admin/users", {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        name: "Integration User",
+        email: "integration.user@example.com",
+        password: "secret123",
+        roles: [2],
+        teams: [{ id: 1, role: "member" }],
+        profile: { name: "Integration User", phone: "+15551234567" },
+      },
+    });
+    expect(response.status()).toBe(201);
+    const body = await response.json();
+    expect(body.data.email).toBe("integration.user@example.com");
+    expect(body.data.roles[0].name).toBe("manager");
+    expect(body.data.teams[0].role).toBe("member");
+    expect(body.data.profile?.phone).toBe("+15551234567");
+    createdUserId = body.data.id;
+  });
+
+  test("shows the created user", async ({ request }) => {
+    //1.- Retrieve the recently created user to verify relationship hydration.
+    const response = await request.get(`/api/admin/users/${createdUserId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.id).toBe(createdUserId);
+    expect(body.data.roles[0].name).toBe("manager");
+    expect(body.data.teams[0].role).toBe("member");
+  });
+
+  test("updates the user with optional fields", async ({ request }) => {
+    //1.- Modify the user to clear roles and adjust the profile data.
+    const response = await request.patch(`/api/admin/users/${createdUserId}`, {
+      headers: { authorization: AUTH_HEADER },
+      data: {
+        name: "Updated Integration User",
+        roles: [],
+        teams: [],
+        profile: { phone: "+15550000000" },
+      },
+    });
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.data.name).toBe("Updated Integration User");
+    expect(body.data.roles).toHaveLength(0);
+    expect(body.data.teams).toHaveLength(0);
+    expect(body.data.profile?.phone).toBe("+15550000000");
+  });
+
+  test("deletes the user", async ({ request }) => {
+    //1.- Remove the user and ensure the API returns the expected status code.
+    const response = await request.delete(`/api/admin/users/${createdUserId}`, {
+      headers: { authorization: AUTH_HEADER },
+    });
+    expect(response.status()).toBe(204);
+  });
+});

--- a/web/tests/secure-pages.spec.ts
+++ b/web/tests/secure-pages.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from "@playwright/test";
+
+const AUTH_HEADER = "Bearer demo-sanctum-token";
+
+const securePaths = [
+  { path: "/api/secure/users", section: "users" },
+  { path: "/api/secure/profile", section: "profile" },
+  { path: "/api/secure/logs", section: "logs" },
+  { path: "/api/secure/errors", section: "errors" },
+];
+
+test.describe("Secure section endpoints", () => {
+  for (const { path, section } of securePaths) {
+    test(`rejects unauthenticated access for ${section}`, async ({ request }) => {
+      //1.- Call the secure endpoint without credentials to verify the guard.
+      const response = await request.get(path);
+      expect(response.status()).toBe(401);
+      await expect(response.json()).resolves.toEqual({ message: "Unauthenticated." });
+    });
+
+    test(`returns authenticated payload for ${section}`, async ({ request }) => {
+      //1.- Provide the Sanctum token to unlock the secure endpoint.
+      const response = await request.get(path, {
+        headers: {
+          authorization: AUTH_HEADER,
+        },
+      });
+
+      //2.- Confirm the meta section value matches the requested area.
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+      expect(body.user).toEqual({
+        id: 1,
+        name: "Demo User",
+        email: "demo.user@example.com",
+      });
+      expect(body.meta).toEqual({ section });
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add shared Sanctum auth helpers and secure section API routes for dashboard, users, profile, logs, and errors
- implement in-memory admin data store with CRUD endpoints for users, roles, permissions, profiles, teams, and settings plus validation utilities
- wire up admin users panel with SWR-powered data fetching, optimistic mutations, and client validation mirroring backend rules
- add Playwright coverage for secure endpoints and each admin resource flow

## Testing
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68decab65b788329b18ab417691cd4ed