### PR TITLE
Add public gameplay world explorer and vehicle gallery

### DIFF
--- a/web/public/3dmodel/vehicles/cargo-hauler.gltf
+++ b/web/public/3dmodel/vehicles/cargo-hauler.gltf
@@ -1,0 +1,45 @@
+{
+  "asset": { "version": "2.0", "generator": "Yamato tooling" },
+  "scene": 0,
+  "scenes": [{ "nodes": [0] }],
+  "nodes": [{ "mesh": 0, "name": "CargoHaulerMesh" }],
+  "meshes": [
+    {
+      "name": "CargoHauler",
+      "primitives": [
+        {
+          "attributes": { "POSITION": 0 },
+          "indices": 1
+        }
+      ]
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AAAAAAAAAD8AAAAAAAAAvwAAAL8AAAAAAAAAPwAAAL8AAAAAAAABAAIA",
+      "byteLength": 42
+    }
+  ],
+  "bufferViews": [
+    { "buffer": 0, "byteOffset": 0, "byteLength": 36, "target": 34962 },
+    { "buffer": 0, "byteOffset": 36, "byteLength": 6, "target": 34963 }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 3,
+      "type": "VEC3",
+      "max": [0.5, 0.5, 0],
+      "min": [-0.5, -0.5, 0]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5123,
+      "count": 3,
+      "type": "SCALAR",
+      "max": [2],
+      "min": [0]
+    }
+  ]
+}

--- a/web/public/3dmodel/vehicles/index.json
+++ b/web/public/3dmodel/vehicles/index.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "sky-runner",
+    "name": "Sky Runner",
+    "role": "Recon skimmer",
+    "description": "Lightweight hovercraft tuned for scouting valleys and ridgelines.",
+    "file": "/3dmodel/vehicles/sky-runner.gltf"
+  },
+  {
+    "id": "cargo-hauler",
+    "name": "Cargo Hauler",
+    "role": "Logistics barge",
+    "description": "Sturdy platform used to move supplies between frontier settlements.",
+    "file": "/3dmodel/vehicles/cargo-hauler.gltf"
+  }
+]

--- a/web/public/3dmodel/vehicles/sky-runner.gltf
+++ b/web/public/3dmodel/vehicles/sky-runner.gltf
@@ -1,0 +1,45 @@
+{
+  "asset": { "version": "2.0", "generator": "Yamato tooling" },
+  "scene": 0,
+  "scenes": [{ "nodes": [0] }],
+  "nodes": [{ "mesh": 0, "name": "SkyRunnerMesh" }],
+  "meshes": [
+    {
+      "name": "SkyRunner",
+      "primitives": [
+        {
+          "attributes": { "POSITION": 0 },
+          "indices": 1
+        }
+      ]
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "data:application/octet-stream;base64,AACAvwAAgL8AAAAAAACAPwAAgL8AAAAAAACAPwAAgD8AAAAAAACAvwAAgD8AAAAAAAABAAIAAAACAAMA",
+      "byteLength": 60
+    }
+  ],
+  "bufferViews": [
+    { "buffer": 0, "byteOffset": 0, "byteLength": 48, "target": 34962 },
+    { "buffer": 0, "byteOffset": 48, "byteLength": 12, "target": 34963 }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 4,
+      "type": "VEC3",
+      "max": [1, 1, 0],
+      "min": [-1, -1, 0]
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5123,
+      "count": 6,
+      "type": "SCALAR",
+      "max": [3],
+      "min": [0]
+    }
+  ]
+}

--- a/web/src/app/(public)/gameplay/layout.tsx
+++ b/web/src/app/(public)/gameplay/layout.tsx
@@ -1,0 +1,20 @@
+import { GameplayNavigation } from "@/components/gameplay/GameplayNavigation"
+
+export default function GameplayLayout({ children }: { children: React.ReactNode }) {
+  //1.- Wrap every gameplay surface with a shared navigation strip for quick context switching.
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-10">
+      <header className="space-y-4">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold">Gameplay laboratory</h1>
+          <p className="text-muted-foreground">
+            Preview the sandbox experiences available to guests before they create a callsign.
+          </p>
+        </div>
+        <GameplayNavigation />
+      </header>
+      {/*2.- Render the active child route below the navigation rail.*/}
+      <main>{children}</main>
+    </div>
+  )
+}

--- a/web/src/app/(public)/gameplay/page.tsx
+++ b/web/src/app/(public)/gameplay/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation"
+
+export default function GameplayIndexPage() {
+  //1.- Direct visitors straight into the world explorer to emphasize immediate immersion.
+  redirect("/gameplay/world")
+}

--- a/web/src/app/(public)/gameplay/vehicles/page.tsx
+++ b/web/src/app/(public)/gameplay/vehicles/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next"
+import { VehicleGallery } from "@/components/gameplay/VehicleGallery"
+import { vehicleCatalog } from "@/lib/gameplay/vehicle-catalog"
+
+export const metadata: Metadata = {
+  title: "Vehicle gallery",
+}
+
+export default function VehicleGalleryPage() {
+  //1.- Pass the validated catalog so pilots can inspect every available craft.
+  return <VehicleGallery vehicles={vehicleCatalog} />
+}

--- a/web/src/app/(public)/gameplay/world/page.tsx
+++ b/web/src/app/(public)/gameplay/world/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next"
+import { WorldExplorer } from "@/components/gameplay/WorldExplorer"
+import { worldRegions } from "@/lib/gameplay/world-regions"
+
+export const metadata: Metadata = {
+  title: "World explorer",
+}
+
+export default function WorldExplorerPage() {
+  //1.- Feed the explorer component with the curated world data so guests can roam instantly.
+  return <WorldExplorer regions={worldRegions} />
+}

--- a/web/src/app/(public)/home/lang/en.json
+++ b/web/src/app/(public)/home/lang/en.json
@@ -4,7 +4,8 @@
     "modules": "Modules",
     "docs": "Docs",
     "register": "Register",
-    "login": "Login"
+    "login": "Login",
+    "gameplay": "Gameplay"
   },
   "badge": {
     "os_enterprise": "Open-source + Enterprise-ready"

--- a/web/src/components/gameplay/GameplayNavigation.tsx
+++ b/web/src/components/gameplay/GameplayNavigation.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+const links = [
+  { href: "/gameplay/world", label: "World explorer" },
+  { href: "/gameplay/vehicles", label: "Vehicle gallery" },
+]
+
+export function GameplayNavigation() {
+  const pathname = usePathname()
+
+  //1.- Highlight the active route so explorers always know which surface they are visiting.
+  return (
+    <nav className="flex flex-wrap gap-2">
+      {links.map(link => {
+        const isActive = pathname === link.href
+        //2.- Toggle emphasis via Tailwind utilities based on the current route.
+        const base = "rounded-full border px-4 py-2 text-sm transition"
+        const active = "border-primary bg-primary/10 text-primary"
+        const inactive = "border-border text-muted-foreground hover:border-primary/60 hover:text-primary"
+        return (
+          <Link key={link.href} href={link.href} className={`${base} ${isActive ? active : inactive}`}>
+            {link.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/web/src/components/gameplay/VehicleGallery.tsx
+++ b/web/src/components/gameplay/VehicleGallery.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import Script from "next/script"
+import type { VehicleModel } from "@/lib/gameplay/vehicle-catalog"
+
+export function VehicleGallery({ vehicles }: { vehicles: VehicleModel[] }) {
+  //1.- Load the web component responsible for rendering GLTF previews only once on the client.
+  const hasVehicles = vehicles.length > 0
+
+  return (
+    <section className="space-y-6">
+      <Script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js" strategy="afterInteractive" />
+
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Vehicle hangar</h1>
+        <p className="text-sm text-muted-foreground">
+          Inspect each craft, rotate the model, and brief your squad before the next sortie.
+        </p>
+      </header>
+
+      {!hasVehicles ? (
+        <div className="rounded-lg border border-dashed border-border p-6 text-center text-muted-foreground">
+          Drop GLTF assets into <code>/public/3dmodel/vehicles</code> with an accompanying metadata entry to see them listed here.
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2">
+          {vehicles.map(vehicle => (
+            <article key={vehicle.id} className="space-y-3 rounded-xl border bg-card p-4 shadow-sm">
+              <header className="space-y-1">
+                <h2 className="text-xl font-semibold">{vehicle.name}</h2>
+                <p className="text-sm uppercase tracking-wide text-muted-foreground">{vehicle.role}</p>
+              </header>
+
+              <model-viewer
+                src={vehicle.file}
+                ar
+                camera-controls
+                auto-rotate
+                autoplay
+                style={{ width: "100%", height: "240px", background: "var(--muted)" }}
+              />
+
+              <p className="text-sm text-muted-foreground">{vehicle.description}</p>
+
+              <a
+                className="inline-flex w-full items-center justify-center rounded-md border border-border px-3 py-2 text-sm font-medium text-primary transition hover:border-primary"
+                href={vehicle.file}
+                download
+              >
+                Download model
+              </a>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/web/src/components/gameplay/WorldExplorer.tsx
+++ b/web/src/components/gameplay/WorldExplorer.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import type { WorldRegion } from "@/lib/gameplay/world-regions"
+
+export function WorldExplorer({ regions }: { regions: WorldRegion[] }) {
+  //1.- Remember the currently highlighted region to drive the detail panel.
+  const [activeRegionId, setActiveRegionId] = useState(regions[0]?.id ?? null)
+
+  //2.- Derive the region metadata every time the selection changes.
+  const activeRegion = useMemo(
+    () => regions.find(region => region.id === activeRegionId) ?? null,
+    [activeRegionId, regions],
+  )
+
+  //3.- Provide a graceful fallback when the dataset is empty.
+  if (!regions.length) {
+    return (
+      <section className="rounded-lg border border-dashed border-border p-6 text-center text-muted-foreground">
+        Add regions to the world-regions registry to explore this planet.
+      </section>
+    )
+  }
+
+  return (
+    <section className="grid gap-6 md:grid-cols-[minmax(0,18rem)_1fr]">
+      <aside className="space-y-3">
+        <h2 className="text-lg font-semibold">Regions</h2>
+        <p className="text-sm text-muted-foreground">
+          Tap a destination to inspect its terrain, story hooks, and logistics notes.
+        </p>
+        <ul className="space-y-2">
+          {regions.map(region => {
+            const isActive = region.id === activeRegionId
+            return (
+              <li key={region.id}>
+                <button
+                  type="button"
+                  onClick={() => setActiveRegionId(region.id)}
+                  className={`w-full rounded-lg border px-4 py-3 text-left transition ${
+                    isActive
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border hover:border-primary/60 hover:text-primary"
+                  }`}
+                >
+                  <div className="text-sm font-medium">{region.name}</div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">{region.climate}</div>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      </aside>
+
+      <article className="rounded-xl border bg-card p-6 shadow-sm">
+        {activeRegion ? (
+          <div className="space-y-4">
+            <header className="space-y-1">
+              <h2 className="text-2xl font-semibold">{activeRegion.name}</h2>
+              <p className="text-sm uppercase tracking-wide text-muted-foreground">{activeRegion.climate}</p>
+            </header>
+            <p className="text-base leading-relaxed text-muted-foreground">{activeRegion.description}</p>
+            <section>
+              <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Points of interest</h3>
+              <ul className="mt-2 grid gap-2 text-sm sm:grid-cols-2">
+                {activeRegion.highlights.map(item => (
+                  <li key={item} className="rounded-md border border-border px-3 py-2">
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          </div>
+        ) : (
+          <div className="grid h-full place-items-center text-muted-foreground">
+            Choose a region on the left to see its story threads.
+          </div>
+        )}
+      </article>
+    </section>
+  )
+}

--- a/web/src/components/public-header.tsx
+++ b/web/src/components/public-header.tsx
@@ -51,6 +51,7 @@ export function PublicHeader() {
         <nav className="flex items-center gap-4 text-sm">
           {/* Use root URLs; your rewrites will map them to /public/... */}
           <NavLink href="/docs">{t("nav.docs")}</NavLink>
+          <NavLink href="/gameplay/world">{t("nav.gameplay")}</NavLink>
           <NavLink href="/register">{t("nav.register")}</NavLink>
           <NavLink href="/login">{t("nav.login")}</NavLink>
 

--- a/web/src/lib/gameplay/vehicle-catalog.ts
+++ b/web/src/lib/gameplay/vehicle-catalog.ts
@@ -1,0 +1,37 @@
+import fs from "fs"
+import path from "path"
+
+export type VehicleModel = {
+  id: string
+  name: string
+  role: string
+  description: string
+  file: string
+}
+
+//1.- Read the vehicle metadata that lives alongside the 3D assets so editors can extend the roster without touching code.
+function loadVehicleCatalog(): VehicleModel[] {
+  const vehiclesDir = path.join(process.cwd(), "public/3dmodel/vehicles")
+  const indexPath = path.join(vehiclesDir, "index.json")
+
+  try {
+    //2.- Parse the curated metadata file and coerce it into the strongly typed catalog.
+    const raw = fs.readFileSync(indexPath, "utf-8")
+    const parsed = JSON.parse(raw) as VehicleModel[]
+
+    //3.- Validate that each entry references an existing asset before exposing it to the UI.
+    return parsed.filter(entry => {
+      if (!entry.file) return false
+      const relative = entry.file.startsWith("/") ? entry.file.slice(1) : entry.file
+      const assetPath = path.join(process.cwd(), "public", relative)
+      return fs.existsSync(assetPath)
+    })
+  } catch (error) {
+    //4.- Fail gracefully by returning an empty catalog when metadata is missing or malformed.
+    console.warn("Vehicle catalog unavailable:", error)
+    return []
+  }
+}
+
+//5.- Export a cached snapshot so server components can access the catalog synchronously.
+export const vehicleCatalog: VehicleModel[] = loadVehicleCatalog()

--- a/web/src/lib/gameplay/world-regions.ts
+++ b/web/src/lib/gameplay/world-regions.ts
@@ -1,0 +1,59 @@
+export type WorldRegion = {
+  id: string
+  name: string
+  climate: "temperate" | "arid" | "tundra" | "tropical"
+  description: string
+  highlights: string[]
+}
+
+//1.- Provide a curated list of explorable regions so the gameplay UI has deterministic content.
+export const worldRegions: WorldRegion[] = [
+  {
+    id: "azure-steppe",
+    name: "Azure Steppe",
+    climate: "temperate",
+    description:
+      "Rolling grasslands dotted with crystalline monoliths that hum whenever storm fronts approach.",
+    highlights: [
+      "Nomadic caravan routes that change every season",
+      "Wind-tempered outposts for long range patrols",
+      "Hidden groves of luminous reeds"
+    ]
+  },
+  {
+    id: "ember-hollows",
+    name: "Ember Hollows",
+    climate: "arid",
+    description:
+      "Sunken basins carved by ancient lava flows now repurposed as a geothermal energy lattice.",
+    highlights: [
+      "Subterranean markets cooled by mineral vents",
+      "Supply depots built into volcanic glass",
+      "Observation towers with panoramic horizons"
+    ]
+  },
+  {
+    id: "silver-fjords",
+    name: "Silver Fjords",
+    climate: "tundra",
+    description:
+      "Glacial cliffs that descend into mirror-like bays, watched over by automated lighthouse beacons.",
+    highlights: [
+      "Icebreaker docks operated by autonomous drones",
+      "Aurora research labs tracing magnetic storms",
+      "Sheltered caverns warmed by thermal springs"
+    ]
+  },
+  {
+    id: "verdant-canopy",
+    name: "Verdant Canopy",
+    climate: "tropical",
+    description:
+      "Layered jungles suspended by colossal trees where ropeways connect research sanctuaries.",
+    highlights: [
+      "Biodiversity observatories perched above the canopy",
+      "Waterfall turbines powering remote villages",
+      "Night markets illuminated by bioluminescent flora"
+    ]
+  }
+]

--- a/web/src/model-viewer.d.ts
+++ b/web/src/model-viewer.d.ts
@@ -1,0 +1,18 @@
+import type React from "react"
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "model-viewer": React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        src?: string
+        ar?: boolean
+        autoplay?: boolean
+        "auto-rotate"?: boolean
+        "camera-controls"?: boolean
+        style?: React.CSSProperties
+      }
+    }
+  }
+}
+
+export {}

--- a/web/tests/gameplay.spec.ts
+++ b/web/tests/gameplay.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test"
+
+const base = "/gameplay"
+
+test.describe("Gameplay surfaces", () => {
+  test("world explorer is publicly reachable", async ({ page }) => {
+    //1.- Navigate straight to the world explorer without authenticating.
+    await page.goto(`${base}/world`)
+
+    //2.- Verify the layout headline and a sample region are rendered.
+    await expect(page.getByRole("heading", { name: "Gameplay laboratory" })).toBeVisible()
+    await expect(page.getByRole("heading", { name: "Regions" })).toBeVisible()
+    await expect(page.getByRole("button", { name: /Azure Steppe/i })).toBeVisible()
+
+    //3.- Confirm selecting a region reveals the detailed description.
+    await page.getByRole("button", { name: /Ember Hollows/i }).click()
+    await expect(page.getByText(/geothermal energy lattice/i)).toBeVisible()
+  })
+
+  test("vehicle gallery lists available models", async ({ page }) => {
+    //1.- Jump to the vehicle gallery and confirm it loads without authentication.
+    await page.goto(`${base}/vehicles`)
+
+    //2.- Ensure the gallery renders cards for each registered model.
+    const cards = page.locator("article", { hasText: "Download model" })
+    await expect(cards).toHaveCount(2)
+
+    //3.- Verify that at least one model can be downloaded for offline inspection.
+    const downloadLink = page.getByRole("link", { name: /Download model/i }).first()
+    const href = await downloadLink.getAttribute("href")
+    expect(href).toContain("/3dmodel/vehicles/sky-runner.gltf")
+  })
+})

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -33,6 +33,7 @@
     "next-env.d.ts",
     "src/**/*.ts",
     "src/**/*.tsx",
+    "src/**/*.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": [


### PR DESCRIPTION
## Summary
- add a public gameplay route group with a world explorer layout and navigation
- introduce a vehicle gallery that reads metadata-driven GLTF models and uses model-viewer for previews
- surface the gameplay entry point in the public header and cover the new flows with Playwright tests

## Testing
- CI=1 npm --prefix web run test:e2e -- tests/gameplay.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e328c032d48329a7f07932e7b47cd1