### PR TITLE
Add public gameplay exploration and vehicle previews

### DIFF
--- a/web/src/3dmodel/vehicles/index.ts
+++ b/web/src/3dmodel/vehicles/index.ts
@@ -1,0 +1,69 @@
+//1.- Define the metadata contract describing how a gameplay vehicle model is represented in the UI layer.
+export type VehicleModel = {
+  id: string
+  name: string
+  role: string
+  description: string
+  previewColor: string
+  stats: {
+    speed: string
+    range: string
+    capacity: string
+  }
+}
+
+//2.- Curate the available vehicle models so the gameplay views can render previews without additional lookups.
+export const vehicleModels: VehicleModel[] = [
+  {
+    id: "scout-rover",
+    name: "Scout Rover",
+    role: "Recon",
+    description:
+      "Lightweight rover tuned for scouting new territories and surfacing navigation data for the fleet.",
+    previewColor: "from-amber-200 via-amber-300 to-orange-300",
+    stats: {
+      speed: "45 km/h",
+      range: "120 km",
+      capacity: "2 research pods",
+    },
+  },
+  {
+    id: "atlas-hauler",
+    name: "Atlas Hauler",
+    role: "Logistics",
+    description:
+      "Heavy cargo platform engineered to move fabrication modules between forward operating bases.",
+    previewColor: "from-slate-200 via-slate-300 to-slate-400",
+    stats: {
+      speed: "30 km/h",
+      range: "240 km",
+      capacity: "18 modular crates",
+    },
+  },
+  {
+    id: "aegis-warden",
+    name: "Aegis Warden",
+    role: "Security",
+    description:
+      "Shielded escort designed to keep expedition columns safe through hazardous corridors.",
+    previewColor: "from-blue-200 via-blue-300 to-indigo-400",
+    stats: {
+      speed: "55 km/h",
+      range: "180 km",
+      capacity: "6 sentinel drones",
+    },
+  },
+  {
+    id: "ember-skimmer",
+    name: "Ember Skimmer",
+    role: "Support",
+    description:
+      "Hover-capable responder that delivers repairs and medkits across uneven terrain.",
+    previewColor: "from-rose-200 via-rose-300 to-red-300",
+    stats: {
+      speed: "65 km/h",
+      range: "150 km",
+      capacity: "4 service racks",
+    },
+  },
+]

--- a/web/src/app/(public)/gameplay/page.tsx
+++ b/web/src/app/(public)/gameplay/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link"
+
+//1.- Provide a simple hub that routes visitors to each gameplay showcase without any authentication gates.
+export default function GameplayHubPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-16">
+      <header className="space-y-4 text-center">
+        <h1 className="text-4xl font-bold text-foreground">Gameplay sandboxes</h1>
+        <p className="text-base text-muted-foreground">
+          Explore the Yamato frontier instantly—jump into world scouting or inspect your vehicles without logging in.
+        </p>
+      </header>
+      <section className="grid gap-6 md:grid-cols-2">
+        <Link
+          href="/gameplay/world"
+          className="group rounded-xl border border-border bg-card p-6 shadow-sm transition hover:border-primary hover:shadow-lg"
+        >
+          <span className="text-sm font-semibold uppercase tracking-wide text-primary">World</span>
+          <h2 className="mt-2 text-2xl font-semibold text-foreground">Open world explorer</h2>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Survey biomes, plan expeditions, and understand terrain challenges—no identity setup required.
+          </p>
+          <span className="mt-4 inline-flex items-center text-sm font-medium text-primary">
+            Enter the world →
+          </span>
+        </Link>
+        <Link
+          href="/gameplay/vehicles"
+          className="group rounded-xl border border-border bg-card p-6 shadow-sm transition hover:border-primary hover:shadow-lg"
+        >
+          <span className="text-sm font-semibold uppercase tracking-wide text-primary">Vehicles</span>
+          <h2 className="mt-2 text-2xl font-semibold text-foreground">Fleet preview bay</h2>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Inspect every rover and hauler in the 3D garage to pick the perfect companion for your journey.
+          </p>
+          <span className="mt-4 inline-flex items-center text-sm font-medium text-primary">
+            View the fleet →
+          </span>
+        </Link>
+      </section>
+    </main>
+  )
+}

--- a/web/src/app/(public)/gameplay/vehicles/page.tsx
+++ b/web/src/app/(public)/gameplay/vehicles/page.tsx
@@ -1,0 +1,16 @@
+import { VehiclePreviewGrid } from "@/components/gameplay/vehicle-preview-grid"
+
+//1.- Surface the vehicle preview bay showcasing every model stored in the 3D catalogue.
+export default function GameplayVehiclesPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-16">
+      <header className="space-y-4">
+        <h1 className="text-4xl font-bold text-foreground">Fleet preview bay</h1>
+        <p className="text-base text-muted-foreground">
+          Compare every vehicle model in the Yamato garage before you commit to a loadout—no login, no pilot callsigns.
+        </p>
+      </header>
+      <VehiclePreviewGrid />
+    </main>
+  )
+}

--- a/web/src/app/(public)/gameplay/world/page.tsx
+++ b/web/src/app/(public)/gameplay/world/page.tsx
@@ -1,0 +1,16 @@
+import { WorldExplorer } from "@/components/gameplay/world-explorer"
+
+//1.- Render the open world explorer so visitors can interact with the map immediately.
+export default function GameplayWorldPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-16">
+      <header className="space-y-4">
+        <h1 className="text-4xl font-bold text-foreground">Open world explorer</h1>
+        <p className="text-base text-muted-foreground">
+          Walk the Yamato frontier instantly—pick a biome to receive mission intel without creating a profile.
+        </p>
+      </header>
+      <WorldExplorer />
+    </main>
+  )
+}

--- a/web/src/app/(public)/home/lang/en.json
+++ b/web/src/app/(public)/home/lang/en.json
@@ -3,6 +3,7 @@
   "nav": {
     "modules": "Modules",
     "docs": "Docs",
+    "gameplay": "Gameplay",
     "register": "Register",
     "login": "Login"
   },
@@ -11,7 +12,7 @@
   },
   "hero": {
     "title": "Ship production-ready SaaS, reliable, secure and audit-ready.",
-    "subtitle": "Yamato Enterprise is a multi-tenant Next.js + shadcn/ui starter with RBAC, audit trails, and a retractable sidebar UX. Build secure dashboards your customers love—without wiring the basics.",
+    "subtitle": "Yamato Enterprise is a multi-tenant Next.js + shadcn/ui starter with RBAC, audit trails, and a retractable sidebar UX. Build secure dashboards your customers love\u2014without wiring the basics.",
     "image_alt": "Yamato Enterprise dashboard preview"
   },
   "kpis": {
@@ -42,7 +43,7 @@
   },
   "features": {
     "heading": "Everything you need",
-    "subheading": "Stop wiring the foundation—focus on your moat. Yamato Enterprise ships batteries-included for modern multi-tenant SaaS.",
+    "subheading": "Stop wiring the foundation\u2014focus on your moat. Yamato Enterprise ships batteries-included for modern multi-tenant SaaS.",
     "items": [
       {
         "title": "Multi-tenant & billing",

--- a/web/src/components/gameplay/vehicle-preview-grid.tsx
+++ b/web/src/components/gameplay/vehicle-preview-grid.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { vehicleModels } from "@/3dmodel/vehicles"
+
+//1.- Present every vehicle card so visitors can quickly compare capabilities without authenticating.
+export function VehiclePreviewGrid() {
+  const [focusedVehicleId, setFocusedVehicleId] = useState(vehicleModels[0]?.id ?? "")
+
+  //2.- Resolve which vehicle is currently highlighted to drive the detail inspector.
+  const focusedVehicle = useMemo(
+    () => vehicleModels.find(vehicle => vehicle.id === focusedVehicleId) ?? vehicleModels[0],
+    [focusedVehicleId],
+  )
+
+  if (!focusedVehicle) {
+    return (
+      <p className="rounded-lg border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        Vehicle data is loading.
+      </p>
+    )
+  }
+
+  return (
+    <section className="grid gap-6 lg:grid-cols-[1.6fr,1fr]">
+      <div className="grid gap-4 sm:grid-cols-2">
+        {vehicleModels.map(vehicle => (
+          <button
+            key={vehicle.id}
+            type="button"
+            onClick={() => setFocusedVehicleId(vehicle.id)}
+            data-active={vehicle.id === focusedVehicle.id}
+            className="group rounded-xl border border-border bg-gradient-to-br from-background to-muted p-4 text-left shadow-sm transition hover:border-primary hover:shadow-lg data-[active=true]:border-primary data-[active=true]:shadow-lg"
+          >
+            <div
+              className={`h-32 rounded-lg bg-gradient-to-br ${vehicle.previewColor} flex items-center justify-center text-sm font-semibold text-primary-foreground`}
+            >
+              {vehicle.name}
+            </div>
+            <div className="mt-4 flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
+              <span>{vehicle.role}</span>
+              <span className="rounded-full bg-primary/10 px-2 py-0.5 font-medium text-primary">
+                {vehicle.stats.speed}
+              </span>
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">{vehicle.description}</p>
+          </button>
+        ))}
+      </div>
+
+      <aside className="flex flex-col justify-between rounded-xl border border-border bg-card p-6 shadow-sm">
+        <div>
+          <h2 className="text-2xl font-semibold text-foreground">{focusedVehicle.name}</h2>
+          <p className="mt-1 text-sm uppercase tracking-wide text-muted-foreground">Role: {focusedVehicle.role}</p>
+          <p className="mt-4 text-base leading-relaxed text-muted-foreground">{focusedVehicle.description}</p>
+        </div>
+        <dl className="mt-6 grid grid-cols-3 gap-4 text-sm">
+          <div>
+            <dt className="font-semibold text-muted-foreground">Top speed</dt>
+            <dd className="text-lg font-bold text-foreground">{focusedVehicle.stats.speed}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-muted-foreground">Range</dt>
+            <dd className="text-lg font-bold text-foreground">{focusedVehicle.stats.range}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-muted-foreground">Payload</dt>
+            <dd className="text-lg font-bold text-foreground">{focusedVehicle.stats.capacity}</dd>
+          </div>
+        </dl>
+        <p className="mt-6 text-xs text-muted-foreground">
+          Choose any vehicle tile to preview its briefing module—no pilot call sign required.
+        </p>
+      </aside>
+    </section>
+  )
+}

--- a/web/src/components/gameplay/world-explorer.tsx
+++ b/web/src/components/gameplay/world-explorer.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+//1.- Model each region of the open world so we can render interactive hotspots the player can explore.
+const worldRegions = [
+  {
+    id: "aurora-basin",
+    name: "Aurora Basin",
+    description:
+      "Crystalline canyons with rich mineral seams and gentle terrain—perfect for onboarding expeditions.",
+    climate: "Temperate",
+    challenge: "Low",
+  },
+  {
+    id: "ember-expanse",
+    name: "Ember Expanse",
+    description:
+      "Volcanic plateaus riddled with thermal vents that power remote fabrication beacons.",
+    climate: "Volcanic",
+    challenge: "Medium",
+  },
+  {
+    id: "zephyr-steppe",
+    name: "Zephyr Steppe",
+    description:
+      "Wide-open lowlands where high winds demand agile vehicles and rapid tactical choices.",
+    climate: "Arid",
+    challenge: "High",
+  },
+  {
+    id: "lumen-reef",
+    name: "Lumen Reef",
+    description:
+      "Bioluminescent wetlands hiding rare flora used for advanced medical synthesis.",
+    climate: "Tropical",
+    challenge: "Medium",
+  },
+] as const
+
+type RegionId = (typeof worldRegions)[number]["id"]
+
+//2.- Expose the interactive explorer that allows unauthenticated visitors to inspect regions.
+export function WorldExplorer() {
+  const initialRegion = (worldRegions[0]?.id ?? "aurora-basin") as RegionId
+  const [activeRegionId, setActiveRegionId] = useState<RegionId>(initialRegion)
+
+  //3.- Compute the active region so the detail panel always reflects the current selection.
+  const activeRegion = useMemo(
+    () => worldRegions.find(region => region.id === activeRegionId) ?? worldRegions[0],
+    [activeRegionId],
+  )
+
+  return (
+    <section className="grid gap-6 lg:grid-cols-[1.4fr,1fr]">
+      <div className="grid gap-4 sm:grid-cols-2">
+        {worldRegions.map(region => (
+          <button
+            key={region.id}
+            type="button"
+            onClick={() => setActiveRegionId(region.id)}
+            data-active={activeRegion?.id === region.id}
+            className="group rounded-xl border border-border bg-gradient-to-br from-background to-muted p-4 text-left shadow-sm transition hover:border-primary hover:shadow-lg data-[active=true]:border-primary data-[active=true]:shadow-lg"
+          >
+            <span className="block text-sm font-semibold uppercase tracking-wide text-primary">{region.climate}</span>
+            <span className="mt-2 block text-lg font-bold text-foreground">{region.name}</span>
+            <p className="mt-3 text-sm text-muted-foreground">{region.description}</p>
+            <span className="mt-4 inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+              Challenge: {region.challenge}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <aside className="flex flex-col justify-between rounded-xl border border-border bg-card p-6 shadow-sm">
+        <div>
+          <h2 className="text-2xl font-semibold text-foreground">Now exploring</h2>
+          <p className="mt-1 text-sm uppercase tracking-wide text-muted-foreground">{activeRegion?.climate} biome</p>
+          <p className="mt-4 text-base leading-relaxed text-muted-foreground">{activeRegion?.description}</p>
+        </div>
+        <dl className="mt-6 grid grid-cols-2 gap-4 text-sm">
+          <div>
+            <dt className="font-semibold text-muted-foreground">Region</dt>
+            <dd className="text-lg font-bold text-foreground">{activeRegion?.name}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-muted-foreground">Difficulty</dt>
+            <dd className="text-lg font-bold text-foreground">{activeRegion?.challenge}</dd>
+          </div>
+        </dl>
+        <p className="mt-6 text-xs text-muted-foreground">
+          Select any biome to update your expedition briefing—no login or character assignment required.
+        </p>
+      </aside>
+    </section>
+  )
+}

--- a/web/src/components/public-header.tsx
+++ b/web/src/components/public-header.tsx
@@ -51,6 +51,7 @@ export function PublicHeader() {
         <nav className="flex items-center gap-4 text-sm">
           {/* Use root URLs; your rewrites will map them to /public/... */}
           <NavLink href="/docs">{t("nav.docs")}</NavLink>
+          <NavLink href="/gameplay">{t("nav.gameplay")}</NavLink>
           <NavLink href="/register">{t("nav.register")}</NavLink>
           <NavLink href="/login">{t("nav.login")}</NavLink>
 

--- a/web/tests/gameplay-vehicles.spec.ts
+++ b/web/tests/gameplay-vehicles.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test"
+import { vehicleModels } from "../src/3dmodel/vehicles"
+
+//1.- Ensure every 3D vehicle model is visible and interactive from the public gameplay view.
+test.describe("Gameplay vehicle preview", () => {
+  test("lists and previews the full fleet without authentication", async ({ page }) => {
+    //2.- Navigate to the fleet preview page as a guest user.
+    await page.goto("/gameplay/vehicles")
+
+    //3.- Confirm the heading renders to establish the experience.
+    await expect(page.getByRole("heading", { name: "Fleet preview bay" })).toBeVisible()
+
+    //4.- Validate that each vehicle defined in the 3D catalogue is present on the screen.
+    for (const vehicle of vehicleModels) {
+      await expect(page.getByRole("button", { name: new RegExp(vehicle.name, "i") })).toBeVisible()
+    }
+
+    //5.- Select a specific vehicle and verify the detail inspector reflects its stats.
+    const focusTarget = vehicleModels[1]
+    await page.getByRole("button", { name: new RegExp(focusTarget.name, "i") }).click()
+    await expect(page.getByText(focusTarget.description)).toBeVisible()
+    await expect(page.getByText(focusTarget.stats.range)).toBeVisible()
+  })
+})

--- a/web/tests/gameplay-world.spec.ts
+++ b/web/tests/gameplay-world.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test"
+
+//1.- Validate that the open world route is interactive without any authentication ceremony.
+test.describe("Gameplay world explorer", () => {
+  test("allows exploring the frontier with no login", async ({ page }) => {
+    //2.- Navigate straight to the gameplay world route as an anonymous visitor.
+    await page.goto("/gameplay/world")
+
+    //3.- Confirm the hero heading renders so the experience is visible to the visitor.
+    await expect(page.getByRole("heading", { name: "Open world explorer" })).toBeVisible()
+
+    //4.- Interact with a biome tile and ensure the detail panel updates accordingly.
+    await page.getByRole("button", { name: /Ember Expanse/ }).click()
+    await expect(page.getByText("Volcanic plateaus riddled with thermal vents")).toBeVisible()
+
+    //5.- Verify the accessibility copy that highlights the lack of login requirements.
+    await expect(page.getByText("no login or character assignment", { exact: false })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- add a public gameplay hub with world and vehicle preview routes that require no authentication
- implement reusable world explorer and fleet preview components backed by shared vehicle metadata
- expose the new gameplay entry in the public header and cover the experiences with Playwright tests

## Testing
- CI=1 pnpm test:e2e *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3291f42408329b6872eea7028c005